### PR TITLE
Fix URLs for Tests in Guides Directory

### DIFF
--- a/Guides/Chain.md
+++ b/Guides/Chain.md
@@ -1,7 +1,7 @@
 # Chain
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Chain.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/ChainTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/ChainTests.swift)]
 
 Concatenates two collections with the same element type, one after another.
 

--- a/Guides/Chunked.md
+++ b/Guides/Chunked.md
@@ -1,7 +1,7 @@
 # Chunked
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Chunked.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/ChunkedTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/ChunkedTests.swift)]
 
 Break a collection into subsequences where consecutive elements pass a binary
 predicate, or where all elements in each chunk project to the same value.

--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -1,7 +1,7 @@
 # Combinations
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Combinations.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/CombinationsTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/CombinationsTests.swift)]
 
 A type that computes combinations of a collection’s elements.
 

--- a/Guides/Cycle.md
+++ b/Guides/Cycle.md
@@ -1,7 +1,7 @@
 # Cycle
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Cycle.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/CycleTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/CycleTests.swift)]
 
 Iterate over a collection forever, or a set number of times.
 

--- a/Guides/Indexed.md
+++ b/Guides/Indexed.md
@@ -1,7 +1,7 @@
 # Indexed
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Indexed.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/IndexedTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/IndexedTests.swift)]
 
 The `enumerated` method, but pairing each element with its index instead of an
 incrementing integer counter.

--- a/Guides/Partition.md
+++ b/Guides/Partition.md
@@ -1,7 +1,7 @@
 # Partition
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Partition.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/PartitionTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/PartitionTests.swift)]
 
 Methods for performing a stable partition on mutable collections, and for 
 finding the partitioning index in an already partitioned collection.

--- a/Guides/Permutations.md
+++ b/Guides/Permutations.md
@@ -1,7 +1,7 @@
 # Permutations
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Permutations.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/PermutationsTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/PermutationsTests.swift)]
 
 A type that computes permutations of a collection’s elements, or of a subset of
 those elements.

--- a/Guides/Product.md
+++ b/Guides/Product.md
@@ -1,7 +1,7 @@
 # Product
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Product.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/ProductTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/ProductTests.swift)]
 
 A function for iterating over every pair of elements in two different
 collections.

--- a/Guides/RandomSampling.md
+++ b/Guides/RandomSampling.md
@@ -1,7 +1,7 @@
 # Random Sampling
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/RandomSample.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/RandomSampleTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift)]
 
 Operations for randomly selecting `k` elements without replacement from a
 sequence or collection.

--- a/Guides/Rotate.md
+++ b/Guides/Rotate.md
@@ -1,7 +1,7 @@
 # Rotate
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Rotate.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/RotateTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/RotateTests.swift)]
 
 A mutating method that rotates the elements of a collection to new positions.
 

--- a/Guides/Unique.md
+++ b/Guides/Unique.md
@@ -1,7 +1,7 @@
 # Unique
 
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Unique.swift) | 
- [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/UniqueTests.swift)]
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/UniqueTests.swift)]
 
 Methods to strip repeated elements from a sequence or collection.
 


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR fixes links in the markdown files in the Guides directory, which incorrectly reference AlgorithmsTests instead of SwiftAlgorithmsTests

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
