### PR TITLE
Clean up early exit checks

### DIFF
--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -159,7 +159,7 @@ extension Collection {
     var current = startIndex
     while true {
       let next = index(after: current)
-      if next == endIndex { break }
+      guard next != endIndex else { break }
       
       if !belongInSameGroup(self[current], self[next]) {
         result.append(self[start..<next])

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -44,7 +44,7 @@ extension Combinations: Sequence {
     internal init(_ combinations: Combinations) {
       self.base = combinations.base
       self.finished = combinations.k < 0
-      self.indexes = combinations.k < 0
+      self.indexes = finished
         ? []
         : Array(combinations.base.indices.prefix(combinations.k))
     }
@@ -78,7 +78,6 @@ extension Combinations: Sequence {
     
       let i = indexes.count - 1
       base.formIndex(after: &indexes[i])
-      if indexes[i] != base.endIndex { return }
 
       var j = i
       while indexes[i] == base.endIndex {
@@ -100,7 +99,7 @@ extension Combinations: Sequence {
     }
     
     public mutating func next() -> [Base.Element]? {
-      if finished { return nil }
+      guard !finished else { return nil }
       defer { advance() }
       return indexes.map { i in base[i] }
     }

--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -26,23 +26,23 @@ extension MutableCollection {
     subrange: Range<Index>,
     by belongsInSecondPartition: (Element) throws-> Bool
   ) rethrows -> Index {
-    if n == 0 { return subrange.lowerBound }
-    if n == 1 {
-      return try belongsInSecondPartition(self[subrange.lowerBound])
-        ? subrange.lowerBound
-        : subrange.upperBound
+    switch n {
+    case 0,
+         1 where try belongsInSecondPartition(self[subrange.lowerBound]):
+      return subrange.lowerBound
+    case 1: return subrange.upperBound
+    default:
+      let h = n / 2, i = index(subrange.lowerBound, offsetBy: h)
+      let j = try stablePartition(
+        count: h,
+        subrange: subrange.lowerBound..<i,
+        by: belongsInSecondPartition)
+      let k = try stablePartition(
+        count: n - h,
+        subrange: i..<subrange.upperBound,
+        by: belongsInSecondPartition)
+      return rotate(subrange: j..<k, toStartAt: i)
     }
-    
-    let h = n / 2, i = index(subrange.lowerBound, offsetBy: h)
-    let j = try stablePartition(
-      count: h,
-      subrange: subrange.lowerBound..<i,
-      by: belongsInSecondPartition)
-    let k = try stablePartition(
-      count: n - h,
-      subrange: i..<subrange.upperBound,
-      by: belongsInSecondPartition)
-    return rotate(subrange: j..<k, toStartAt: i)
   }
   
   /// Moves all elements satisfying the given predicate into a suffix of the

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -56,7 +56,6 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of `subrange`.
   public mutating func reverse(subrange: Range<Index>) {
-    if subrange.isEmpty { return }
     var lo = subrange.lowerBound
     var hi = subrange.upperBound
     


### PR DESCRIPTION
Early exits using if statements have been changed to use guard where appropriate.

Redundant early exits, where the statement is immediately followed by an equivalent statement with the same behavior, have been removed.

MutableCollection.stablePartition(count:, subrange:, by:) has been restructured to use a switch statement, since a substantial portion of the function consisted of consecutive if statements comparing the same parameter.

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This pull request cleans up some of the early exits in the algorithms, either by changing them to use guard or by removing them entirely if they seem clearly redundant.

I’m new to this project, so I cannot rule out the possibility of errors. I ran the unit tests and checked everything manually, but a regression may have been introduced even by changes as simple as this.

I have also not run performance profiling to confirm my changes have no negative impact.

Finally, as there is no official code style for this project, I cannot be sure that I have followed it. The existing code seems to follow normal Swift library conventions, but I may have overlooked something.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
