### PR TITLE
Fix build on Windows

### DIFF
--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -13,6 +13,9 @@
 #if canImport(Glibc)
 @_implementationOnly
 import Glibc
+#elseif canImport(ucrt)
+@_implementationOnly
+import ucrt
 #elseif canImport(Darwin)
 @_implementationOnly
 import Darwin


### PR DESCRIPTION
`log` & `exp` functions are declared in `ucrt.corecrt.math` module on Windows.

This change makes the package buildable with SwiftPM on Windows.

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
