### PR TITLE
Added a heap view to Collection that manages a simple Heap structure

### DIFF
--- a/Guides/Heap.md
+++ b/Guides/Heap.md
@@ -1,0 +1,96 @@
+# Heap
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Heap.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/AlgorithmsTests/HeapTests.swift)]
+
+A type that provides a heap view of a collection’s elements, or of a subset of those 
+elements. 
+
+The heap view puts the maximum element (defined by the provided comparator
+closure) at subscript 0 in the heap, and ensures that when `pop()` is called that
+the maximum is removed and retrieved and that the new maximum is moved to 
+subscript 0. The heap property, where each node in the tree is greater than its children,
+is preserved by the heap operations. 
+
+The heap does not alter the underlying collection. Multiple heaps can refer to the 
+same collection at the same time. But if the underlying collection is mutated, any heaps
+that refer to it will become invalid. 
+
+By calling the `pop()` method repeatedly a client can retrieve the elements of 
+the collection in order according to the comparator without sorting the whole collection. 
+
+```swift
+let characters = "Woven silk pyjamas exchanged for blue quartz."
+
+let comparators : [(Character, Character) -> Bool] =
+  [{$0 <= $1},
+   {$1 <= $0}]
+   
+for comparator in comparators {
+  var heap = Heap(arrayUnderTest, comparator: comparator)
+
+  var oldChar: Character? = .none
+  while let newchar = heap.pop() {
+    oldChar = newchar
+    print(newchar)
+  }
+}
+```
+will print the characters from `z` down to ` `, including duplicates, then will print
+the characters in ascending order, from ` ` to `z` again. 
+
+The comparator is a closure with type `(Base.Element, Base.Element) -> Bool`. 
+It should return true if the left-hand argument is less-than to the right-hand 
+argument according to the partial ordering you want for the heap.  
+
+## Detailed Design
+
+The `heap(comparator:)` method is declared as a `Collection` extension and 
+returns a `Heap` type. The `Element` of the collection does not need to conform to 
+`Comparable`:
+
+```swift
+extension Collection {
+  public func heap(comparator: @escaping (Element, Element) -> Bool) 
+                -> Heap<Self> {
+    return Heap(self, comparator: comparator)
+  }
+}
+```
+
+The `Heap` type itself is a struct that can be subscripted but does not conform to any 
+protocols. 
+
+The `Heap` stores an array of the indexes to the underlying collection, so it requires 
+storage for an `Array<Base.Index>` with `base.count` elements. 
+
+### Complexity
+
+Calling `heap()` is an _O(n)_ operation, where _n_ is the number of elements in the 
+base collection.
+
+Calling `pop` is an _O(lg n)_ operation, where _lg_ is the base 2 log and _n_ in this case
+is the number of remaining elements in the permutation index. (This is proportional to 
+`base.count` so _n_ could be the number of elements in the base collection.)
+
+### Naming
+
+The `Heap` name is common, but it does reveal the underlying implementation. There
+are some Swift Evolution pitches using different names. The advantage to this name is 
+that the implementation and its specific complexity are clear. 
+
+The actual heap itself is a data structure--it's possible that this should be part of a 
+hypothetical `DataStructures` package. 
+
+Another approach would be to make `Heap` conform to  `IteratorProtocol`, 
+and then to have the `next()` method extract and remove the top element in the heap. 
+That would interoperate with some `for...in` loops. 
+
+### Comparison with other langauges
+
+**C++:** The `<algorithm>` library defines `make_heap` and a variety of other heap-maintenance
+operations. 
+
+**Rust/Ruby/Python:** _I have not looked yet, but I believe that Ruby and Python 
+do not have a partially-sorted kind of thing._
+

--- a/Sources/Algorithms/Heap.swift
+++ b/Sources/Algorithms/Heap.swift
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A heap view of a collection's elements.
+public struct Heap<Base: Collection> where Base.Element : Comparable {
+  /// The base collection.
+  public let base: Base
+
+  var indexes: [Base.Index]
+
+  internal init(_ base: Base) {
+    self.base = base
+    self.indexes = Array(base.indices)
+  }
+
+  internal func doublePlusIncr(base: Base, x : Base.Index, increment: Int) -> Base.Index? {
+    let lastIndex = base.index(base.endIndex, offsetBy: -1)
+    let distance = base.distance(from: base.startIndex, to: x)
+    if let distance2 = base.index(x,
+                                  offsetBy: distance,
+                                  limitedBy: lastIndex) {
+      return base.index(distance2, offsetBy: increment, limitedBy: lastIndex)
+    } else {
+      return .none
+    }
+
+  }
+
+  /// 2*i + 1
+  public func leftChild(x : Base.Index) -> Base.Index? {
+    doublePlusIncr(base: base, x: x, increment: 1)
+  }
+
+  /// 2*i + 2
+  public func rightChild(x: Base.Index) -> Base.Index? {
+    doublePlusIncr(base: base, x: x, increment: 2)
+  }
+
+  /// .none for the root node, otherwise (i-1) / 2
+  public func parent(x: Base.Index) -> Base.Index? {
+    let distance = base.distance(from: base.startIndex, to: x)
+    if distance == 0 {
+      return .none
+    }
+
+    let (halfDistance, _) = (distance - 1).quotientAndRemainder(dividingBy: 2)
+
+    // if remainder == 0, left child,
+    // if remainder == 1, right child
+
+    return base.index(base.startIndex, offsetBy: halfDistance)
+  }
+
+  /* operations on array of indices */
+
+  /// swaps two entries in the array of indices
+  /// TODO: get the index type from [Base.Index]
+  mutating func swap(x: Int,
+                     y: Int) -> Bool {
+    if indexes.indices.contains(x) && indexes.indices.contains(y) {
+      let tmp = indexes[x]
+      indexes[x] = indexes[y]
+      indexes[y] = tmp
+      return true
+    } else {
+      return false
+    }
+  }
+
+  /**
+   * Returns translated value indirectly, through the indexes array.
+   * self[0] is the root of the heap and is the max of the heap
+   */
+  subscript(index: Int) -> Base.Element? {
+    get {
+      if indexes.indices.contains(index) {
+        let underlyingIndex = indexes[index]
+        return base[underlyingIndex]
+      } else {
+        return .none
+      }
+    }
+  }
+
+  /// takes parent node in indexes array as argument.
+  /// postcondition: parent node is greater than immediate chidren.
+
+  mutating func heapThree(rootNodeIndex: Int) {
+
+    let leftChildIndex = 2 * rootNodeIndex + 1
+    let rightChildIndex = 2 * rootNodeIndex + 2
+
+    let rootValue = self[rootNodeIndex]!
+    let leftValueOptional = self[leftChildIndex]
+    let rightValueOptional = self[rightChildIndex]
+
+    switch (leftValueOptional, rightValueOptional) {
+    case let (.some(leftValue), .some(rightValue)) where rootValue < rightValue && leftValue < rightValue:
+      let _ = swap(x: rightChildIndex, y: rootNodeIndex)
+      heapThree(rootNodeIndex: rightChildIndex)
+    case let (.some(leftValue), .some(rightValue)) where rootValue < leftValue && rightValue < leftValue:
+      let _ = swap(x: leftChildIndex, y: rootNodeIndex)
+      heapThree(rootNodeIndex: leftChildIndex)
+        //swap root, left
+    case (.some(_), .some(_)):
+      // rootvalue > right and left values
+      break
+    case let (.some(leftValue), .none) where rootValue < leftValue:
+      let _ = swap(x: leftChildIndex, y: rootNodeIndex)
+      heapThree(rootNodeIndex: leftChildIndex)
+    case (.some(_), .none):
+      // rootvalue > leftValue
+      break
+    case let (.none, .some(rightValue)) where rootValue < rightValue:
+      let _ = swap(x: rightChildIndex, y: rootNodeIndex)
+      heapThree(rootNodeIndex: rightChildIndex)
+        //swap root, right
+    case (.none, .some(_)):
+      //rootvalue > rightValue
+      break
+    case (.none, .none) :
+      // rootvalue is only value
+      break
+    }
+    //    orders: root  < left  < right -> swap root, right
+    //          : left  < root  < right -> swap root, right
+    //          : root  < right < left  -> swap root, left
+    //          : right < root  < left  -> swap root, left
+    //          : right < left  < root  -> no swap
+    //          : left  < right < root  -> no swap
+    //  .none < everything
+    //  equal values go left < right < root
+
+  }
+
+  func isHeapThree(rootNodeIndex: Int) -> Bool {
+    let leftChildIndex = 2 * rootNodeIndex + 1
+    let rightChildIndex = 2 * rootNodeIndex + 2
+
+    let rootValue = self[rootNodeIndex]!
+    let leftValueOptional = self[leftChildIndex]
+    let rightValueOptional = self[rightChildIndex]
+
+    switch (leftValueOptional, rightValueOptional) {
+    case let (.some(leftValue), .some(rightValue)):
+      return leftValue <= rootValue && rightValue <= rootValue
+    case let (.some(leftValue), .none):
+      return leftValue <= rootValue
+    case let (.none, .some(rightValue)):
+      return rightValue <= rootValue
+    case (.none, .none):
+      return true
+    }
+  }
+
+  func isHeapThreeAll() -> Bool {
+    var result: Bool = true
+    for nodeIndex in indexes.indices.reversed() {
+      let thisResult = isHeapThree(rootNodeIndex: nodeIndex)
+      assert(thisResult)
+      result = result && thisResult
+    }
+    return result
+//    indexes.indices.reversed().allSatisfy {isHeapThree(rootNodeIndex:$0)}
+  }
+  
+  /// starts at last entry in last inner node
+  /// calls heapThree on each
+  /// works backward to beginning of array
+  mutating func makeHeap() {
+    for nodeIndex in indexes.indices.reversed() {
+      heapThree(rootNodeIndex: nodeIndex)
+    }
+  }
+}
+ 
+//===----------------------------------------------------------------------===//
+// heap()
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  public func heap() -> Heap<Self> where Self: Comparable {
+    return Heap(self)
+  }
+}

--- a/Sources/Algorithms/Heap.swift
+++ b/Sources/Algorithms/Heap.swift
@@ -10,8 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A heap view of a collection's elements.
-public struct Heap<Base> where Base: Collection,
-                               Base.Element : Comparable {
+public struct Heap<Base> where Base: Collection {
   private let base: Base
   /** the permutation are stored as an array of indices into the base
    * possibly there's a more efficient way to store them, for instance
@@ -112,8 +111,6 @@ public struct Heap<Base> where Base: Collection,
     }
     return result
   }
-  /// takes parent node in indexes array as argument.
-  /// postcondition: parent node is greater than immediate chidren.
 
   /**
    * Assigns root node to the max of the root and the two immediate children.
@@ -168,10 +165,11 @@ public struct Heap<Base> where Base: Collection,
     }
   }
 
-  /// starts at last entry in last inner node
-  /// calls heapThree on each
-  /// works backward to beginning of array
-  /// TODO: don't run on leaves
+  /** Creates a heap for a whole collection.
+   *  Starts at the last entry and works backward to beginning.
+   */
+  // TODO: don't run on leaves
+  //       it is straightforward to ignore the last n entries that have no children.
   internal mutating func makeHeap(comparator: (Base.Element, Base.Element) -> Bool) {
     for nodeIndex in permutation.indices.reversed() {
       heapThree(rootNodeIndex: nodeIndex,
@@ -185,8 +183,8 @@ public struct Heap<Base> where Base: Collection,
 //===----------------------------------------------------------------------===//
 
 extension Collection {
-  public func heap(comparator: @escaping (Element, Element) -> Bool) -> Heap<Self>
-    where Self: Comparable {
+  public func heap(comparator: @escaping (Element, Element) -> Bool)
+              -> Heap<Self> {
     return Heap(self, comparator: comparator)
   }
 }

--- a/Sources/Algorithms/Heap.swift
+++ b/Sources/Algorithms/Heap.swift
@@ -10,6 +10,15 @@
 //===----------------------------------------------------------------------===//
 
 /// A heap view of a collection's elements.
+
+// Some to-dos:
+// TODO: If the base collection is modified, the heap condition can be
+//   violated. Ideally we'd notice this and recreate the heap.
+// TODO: don't run `heapthree` on leaves in makeHeap
+//       it is straightforward to ignore the last n entries that have no children.
+// TODO: figure out if we can do better than creating an array of permutations.
+// TODO: figure out if we can store the comparator closure as non-escaping.
+
 public struct Heap<Base> where Base: Collection {
   private let base: Base
   /** the permutation are stored as an array of indices into the base
@@ -18,8 +27,7 @@ public struct Heap<Base> where Base: Collection {
    * The heap condition holds for the elements that this array points to.
    *
   */
-  // TODO: If the base collection is modified, the heap condition can be
-  //   violated. Ideally we'd notice this and recreate the heap.
+
   private var permutation: Array<Base.Index>
 
   /*
@@ -168,8 +176,6 @@ public struct Heap<Base> where Base: Collection {
   /** Creates a heap for a whole collection.
    *  Starts at the last entry and works backward to beginning.
    */
-  // TODO: don't run on leaves
-  //       it is straightforward to ignore the last n entries that have no children.
   internal mutating func makeHeap(comparator: (Base.Element, Base.Element) -> Bool) {
     for nodeIndex in permutation.indices.reversed() {
       heapThree(rootNodeIndex: nodeIndex,

--- a/Sources/Algorithms/Heap.swift
+++ b/Sources/Algorithms/Heap.swift
@@ -90,6 +90,18 @@ public struct Heap<Base: Collection> where Base.Element : Comparable {
     }
   }
 
+  mutating func pop() -> Base.Element? {
+    if indexes.isEmpty {
+      return .none
+    }
+    let result = self[0]
+    let lastIndex = indexes.popLast()
+    if !indexes.isEmpty, let x = lastIndex {
+      indexes[0] = x
+      heapThree(rootNodeIndex: 0)
+    }
+    return result
+  }
   /// takes parent node in indexes array as argument.
   /// postcondition: parent node is greater than immediate chidren.
 
@@ -103,10 +115,10 @@ public struct Heap<Base: Collection> where Base.Element : Comparable {
     let rightValueOptional = self[rightChildIndex]
 
     switch (leftValueOptional, rightValueOptional) {
-    case let (.some(leftValue), .some(rightValue)) where rootValue < rightValue && leftValue < rightValue:
+    case let (.some(leftValue), .some(rightValue)) where rootValue < rightValue && leftValue <= rightValue:
       let _ = swap(x: rightChildIndex, y: rootNodeIndex)
       heapThree(rootNodeIndex: rightChildIndex)
-    case let (.some(leftValue), .some(rightValue)) where rootValue < leftValue && rightValue < leftValue:
+    case let (.some(leftValue), .some(rightValue)) where rootValue < leftValue && rightValue <= leftValue:
       let _ = swap(x: leftChildIndex, y: rootNodeIndex)
       heapThree(rootNodeIndex: leftChildIndex)
         //swap root, left

--- a/Tests/SwiftAlgorithmsTests/HeapTests.swift
+++ b/Tests/SwiftAlgorithmsTests/HeapTests.swift
@@ -13,128 +13,55 @@ import XCTest
 @testable import Algorithms
 
 final class HeapTests: XCTestCase {
-  func testBinaryTree() {
-    let c = "ABCDEFGHIJKLMNOPQRSTUVWXYZA"
 
-    let leftIndex = c.index(c.startIndex, offsetBy: 7)
-    let rightIndex = c.index(c.startIndex, offsetBy: 22)
-    let arrayUnderTest = c[leftIndex...rightIndex]
+  func testPopCharacters() {
+    let arraysToTest = [
+      "kdrienspeksanewerdof",
+      "ermdie,kdsap,erl;kamrek;qermdkll;rel;nsn8cvtt3w7flpr9ok2"
+    ]
 
-    let heap = arrayUnderTest.heap()
+    let comparators : [(Character, Character) -> Bool] =
+      [{$0 <= $1},
+       {$1 <= $0}]
+    for arrayUnderTest in arraysToTest {
+      for comparator in comparators {
+        var heap = Heap(arrayUnderTest, comparator: comparator)
 
-    for j in arrayUnderTest.indices {
-
-      let leftChildIndex = heap.leftChild(x: j)
-      let rightChildIndex = heap.rightChild(x: j)
-      let parentIndex = heap.parent(x: j)
-
-      let value = arrayUnderTest[j]
-      let leftValue = leftChildIndex.map {arrayUnderTest[$0]} ?? "ø"
-      let rightValue = rightChildIndex.map {arrayUnderTest[$0]} ?? "ø"
-      let parentValue = parentIndex.map {arrayUnderTest[$0]} ?? "ø"
-
-//      let jDistance = arrayUnderTest.distance(from: arrayUnderTest.startIndex,
-//                                              to: j)
-//      let jLeftDistance = leftChild.map {
-//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
-//      }
-//      let jRightDistance = rightChild.map {
-//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
-//      }
-//
-//      let parentDistance = i.parent(x:j).map {
-//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
-//      }
-
-      print(value,
-            leftValue,
-            rightValue,
-            parentValue)
-      print()
-    }
-
-  }
-
-  public func testSwap() {
-
-    let c = "ABCDEFGHIJKLMNOPQRSTUVWXYZA"
-
-    let leftIndex = c.index(c.startIndex, offsetBy: 7)
-    let rightIndex = c.index(c.startIndex, offsetBy: 22)
-    let arrayUnderTest = c[leftIndex...rightIndex]
-
-    var heap = arrayUnderTest.heap()
-
-    let swaps = [
-    (0, 0),
-    (3, 4),
-    (5, 8),
-    (8, 10),
-    (11, 9),
-    (1, 30),
-    (29, 1)]
-
-    // postcondition: true -> i.valueAt[left] == before[right], after[right] == before[left]
-    //                false -> after == before
-    for (left, right) in swaps {
-      let beforeLeft = heap[left]
-      let beforeRight = heap[right]
-
-      let swapped = heap.swap(x: left, y: right)
-
-      var after = ""
-      for index in 0..<arrayUnderTest.count {
-        after.append(heap[index] ?? "ø")
-      }
-      print(left, right, swapped)
-      print(after)
-
-      let afterLeft = heap[left]
-      let afterRight = heap[right]
-
-      if (swapped) {
-        XCTAssert(beforeLeft == afterRight)
-        XCTAssert(beforeRight == afterLeft)
+        var oldChar: Character? = .none
+        while let newchar = heap.pop() {
+          if let old = oldChar {
+            XCTAssert(comparator(newchar, old))
+          }
+          oldChar = newchar
+          print(newchar)
+        }
       }
     }
   }
 
-  func testMakeHeap() {
-    let c = "kdrienspeksanewerdof"
-    let arrayUnderTest = c
+  func testPopInts() {
+    let arraysToTest = [
+      [9, 2, 40, 302, 3, 321, 1, 3, 4],
+      [4032, 3453, 2340, 9482, 8323, 34, 9284, 2342, 9233, 3454, 2395, 8273, 6574,
+      8342, 7345, 9274, 3491, 9342, 8234, 7234, 6123, 8342, 7231, 9349]
+    ]
 
-    var heap = Heap(arrayUnderTest)
+    let comparators : [(Int, Int) -> Bool] =
+      [{$0 <= $1},
+       {$1 <= $0}]
+    for arrayUnderTest in arraysToTest {
+      for comparator in comparators {
+        var heap = Heap(arrayUnderTest, comparator: comparator)
 
-    var before = String()
-    for i in heap.indexes.indices {
-      before.append(heap[i]!)
-    }
-
-    heap.makeHeap()
-
-    var after = String()
-    for i in heap.indexes.indices {
-      after.append(heap[i]!)
-    }
-
-    print(before)
-    print(after)
-
-    XCTAssert(heap.isHeapThreeAll())
-
-  }
-
-
-  func testPop() {
-    let c = "kdrienspeksanewerdof"
-    let arrayUnderTest = c
-
-    var heap = Heap(arrayUnderTest)
-
-    heap.makeHeap()
-
-    while (!heap.indexes.isEmpty) {
-      print(heap.pop()!)
+        var oldValue: Int? = .none
+        while let newValue = heap.pop() {
+          if let old = oldValue {
+            XCTAssert(comparator(newValue, old))
+          }
+          oldValue = newValue
+          print(newValue)
+        }
+      }
     }
   }
 }

--- a/Tests/SwiftAlgorithmsTests/HeapTests.swift
+++ b/Tests/SwiftAlgorithmsTests/HeapTests.swift
@@ -14,53 +14,132 @@ import XCTest
 
 final class HeapTests: XCTestCase {
 
-  func testPopCharacters() {
-    let arraysToTest = [
-      "kdrienspeksanewerdof",
-      "ermdie,kdsap,erl;kamrek;qermdkll;rel;nsn8cvtt3w7flpr9ok2",
-      "Woven silk pyjamas exchanged for blue quartz."
-    ]
+  let arraysToTest = [
+    "kdrienspeksanewerdof",
+    "ermdie,kdsap,erl;kamrek;qermdkll;rel;nsn8cvtt3w7flpr9ok2",
+    "Woven silk pyjamas exchanged for blue quartz."
+  ]
 
-    let comparators : [(Character, Character) -> Bool] =
-      [{$0 <= $1},
-       {$1 <= $0}]
-    for arrayUnderTest in arraysToTest {
-      for comparator in comparators {
-        var heap = Heap(arrayUnderTest, comparator: comparator)
+  let comparators : [(Character, Character) -> Bool] =
+    [{$0 <= $1},
+     {$1 <= $0}]
 
-        var oldChar: Character? = .none
-        while let newchar = heap.pop() {
-          if let old = oldChar {
-            XCTAssert(comparator(newchar, old))
-          }
-          oldChar = newchar
+  let arraysToTestInt : [[Int]] = [
+    [9, 2, 40, 302, 3, 321, 1, 3, 4],
+    [4032, 3453, 2340, 9482, 8323, 34, 9284, 2342, 9233, 3454, 2395, 8273, 6574,
+    8342, 7345, 9274, 3491, 9342, 8234, 7234, 6123, 8342, 7231, 9349]
+  ]
+
+  let comparatorsInt : [(Int, Int) -> Bool] =
+    [{$0 <= $1},
+     {$1 <= $0}]
+  /**
+   * Checks that root is more than any other element of the heap
+   *   according to the comparator logic (where left < right)
+   *   by calling the comparator repeatedly on the other elements.
+   */
+  func invariantRootIsMax<T>(heap: Heap<T>,
+                             comparator: (T.Element, T.Element) -> Bool,
+                             output: Bool = false)
+                                -> Bool {
+
+    if let rootValue = heap[0] {
+      var i = 1
+      while let toCompare = heap[i] {
+        if output {
+          print(i, toCompare, rootValue)
         }
+        if !comparator(toCompare, rootValue) {
+          return false
+        }
+        i += 1
+      }
+    }
+    return true
+  }
+
+  func harness<T>(collection: T,
+                  comparator: @escaping (T.Element, T.Element) -> Bool,
+                  output: Bool = false)
+                    where T: Collection {
+    var heap = Heap(collection,
+                    comparator: comparator)
+    XCTAssert(invariantRootIsMax(heap: heap,
+                                 comparator: comparator,
+                                 output: output))
+    var oldElementQ: T.Element? = .none
+
+    XCTAssert(heap.consumedCount == 0)
+    XCTAssert(heap.count == heap.collectionCount)
+
+    while let newElement = heap.pop() {
+      if let oldElement = oldElementQ {
+        XCTAssert(comparator(newElement, oldElement))
+        XCTAssert(invariantRootIsMax(heap: heap,
+                                     comparator: comparator,
+                                     output: output))
+
+        XCTAssert(heap.collectionCount == heap.consumedCount + heap.count)
+
+      }
+      oldElementQ = newElement
+    }
+
+    XCTAssert(heap.consumedCount == heap.collectionCount)
+    XCTAssert(heap.count == 0)
+  }
+
+
+  func testPopCharacters() {
+
+    for arrayUnderTest : String in arraysToTest {
+      for comparator in comparators {
+        harness(collection: arrayUnderTest,
+                comparator: comparator)
       }
     }
   }
 
   func testPopInts() {
-    let arraysToTest = [
-      [9, 2, 40, 302, 3, 321, 1, 3, 4],
-      [4032, 3453, 2340, 9482, 8323, 34, 9284, 2342, 9233, 3454, 2395, 8273, 6574,
-      8342, 7345, 9274, 3491, 9342, 8234, 7234, 6123, 8342, 7231, 9349]
-    ]
 
-    let comparators : [(Int, Int) -> Bool] =
-      [{$0 <= $1},
-       {$1 <= $0}]
-    for arrayUnderTest in arraysToTest {
-      for comparator in comparators {
-        var heap = Heap(arrayUnderTest, comparator: comparator)
-
-        var oldValue: Int? = .none
-        while let newValue = heap.pop() {
-          if let old = oldValue {
-            XCTAssert(comparator(newValue, old))
-          }
-          oldValue = newValue
-        }
+    for arrayUnderTest : [Int] in arraysToTestInt {
+      for comparator in comparatorsInt {
+        harness(collection: arrayUnderTest,
+                comparator: comparator)
       }
     }
   }
+
+
+  func testSubCollections() {
+
+    for arrayUnderTest : String in arraysToTest {
+      for comparator in comparators {
+        let startIndex = arrayUnderTest.index(arrayUnderTest.startIndex,
+                                              offsetBy: 5)
+        let endIndex = arrayUnderTest.index(arrayUnderTest.startIndex,
+                                            offsetBy: 17)
+
+        let subarray = arrayUnderTest[startIndex ..< endIndex]
+        harness(collection: subarray,
+                comparator: comparator)
+      }
+    }
+  }
+
+  func testChained() {
+
+    let extraArray = "chain and train in vain"
+
+    for arrayUnderTest : String in arraysToTest {
+      for comparator in comparators {
+        let chained = arrayUnderTest.chained(with: extraArray)
+
+        harness(collection: chained,
+                comparator: comparator)
+      }
+    }
+  }
+
 }
+

--- a/Tests/SwiftAlgorithmsTests/HeapTests.swift
+++ b/Tests/SwiftAlgorithmsTests/HeapTests.swift
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import Algorithms
+
+final class HeapTests: XCTestCase {
+  func testBinaryTree() {
+    let c = "ABCDEFGHIJKLMNOPQRSTUVWXYZA"
+
+    let leftIndex = c.index(c.startIndex, offsetBy: 7)
+    let rightIndex = c.index(c.startIndex, offsetBy: 22)
+    let arrayUnderTest = c[leftIndex...rightIndex]
+
+    let heap = arrayUnderTest.heap()
+
+    for j in arrayUnderTest.indices {
+
+      let leftChildIndex = heap.leftChild(x: j)
+      let rightChildIndex = heap.rightChild(x: j)
+      let parentIndex = heap.parent(x: j)
+
+      let value = arrayUnderTest[j]
+      let leftValue = leftChildIndex.map {arrayUnderTest[$0]} ?? "ø"
+      let rightValue = rightChildIndex.map {arrayUnderTest[$0]} ?? "ø"
+      let parentValue = parentIndex.map {arrayUnderTest[$0]} ?? "ø"
+
+//      let jDistance = arrayUnderTest.distance(from: arrayUnderTest.startIndex,
+//                                              to: j)
+//      let jLeftDistance = leftChild.map {
+//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
+//      }
+//      let jRightDistance = rightChild.map {
+//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
+//      }
+//
+//      let parentDistance = i.parent(x:j).map {
+//        arrayUnderTest.distance(from: arrayUnderTest.startIndex, to: $0)
+//      }
+
+      print(value,
+            leftValue,
+            rightValue,
+            parentValue)
+      print()
+    }
+
+  }
+
+  public func testSwap() {
+
+    let c = "ABCDEFGHIJKLMNOPQRSTUVWXYZA"
+
+    let leftIndex = c.index(c.startIndex, offsetBy: 7)
+    let rightIndex = c.index(c.startIndex, offsetBy: 22)
+    let arrayUnderTest = c[leftIndex...rightIndex]
+
+    var heap = arrayUnderTest.heap()
+
+    let swaps = [
+    (0, 0),
+    (3, 4),
+    (5, 8),
+    (8, 10),
+    (11, 9),
+    (1, 30),
+    (29, 1)]
+
+    // postcondition: true -> i.valueAt[left] == before[right], after[right] == before[left]
+    //                false -> after == before
+    for (left, right) in swaps {
+      let beforeLeft = heap[left]
+      let beforeRight = heap[right]
+
+      let swapped = heap.swap(x: left, y: right)
+
+      var after = ""
+      for index in 0..<arrayUnderTest.count {
+        after.append(heap[index] ?? "ø")
+      }
+      print(left, right, swapped)
+      print(after)
+
+      let afterLeft = heap[left]
+      let afterRight = heap[right]
+
+      if (swapped) {
+        XCTAssert(beforeLeft == afterRight)
+        XCTAssert(beforeRight == afterLeft)
+      }
+    }
+  }
+
+  func testMakeHeap() {
+    let c = "kdrienspeksanewerdof"
+    let arrayUnderTest = c
+
+    var heap = Heap(arrayUnderTest)
+
+    var before = String()
+    for i in heap.indexes.indices {
+      before.append(heap[i]!)
+    }
+
+    heap.makeHeap()
+
+    var after = String()
+    for i in heap.indexes.indices {
+      after.append(heap[i]!)
+    }
+
+    print(before)
+    print(after)
+
+    XCTAssert(heap.isHeapThreeAll())
+
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/HeapTests.swift
+++ b/Tests/SwiftAlgorithmsTests/HeapTests.swift
@@ -123,4 +123,18 @@ final class HeapTests: XCTestCase {
     XCTAssert(heap.isHeapThreeAll())
 
   }
+
+
+  func testPop() {
+    let c = "kdrienspeksanewerdof"
+    let arrayUnderTest = c
+
+    var heap = Heap(arrayUnderTest)
+
+    heap.makeHeap()
+
+    while (!heap.indexes.isEmpty) {
+      print(heap.pop()!)
+    }
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/HeapTests.swift
+++ b/Tests/SwiftAlgorithmsTests/HeapTests.swift
@@ -17,7 +17,8 @@ final class HeapTests: XCTestCase {
   func testPopCharacters() {
     let arraysToTest = [
       "kdrienspeksanewerdof",
-      "ermdie,kdsap,erl;kamrek;qermdkll;rel;nsn8cvtt3w7flpr9ok2"
+      "ermdie,kdsap,erl;kamrek;qermdkll;rel;nsn8cvtt3w7flpr9ok2",
+      "Woven silk pyjamas exchanged for blue quartz."
     ]
 
     let comparators : [(Character, Character) -> Bool] =
@@ -33,7 +34,6 @@ final class HeapTests: XCTestCase {
             XCTAssert(comparator(newchar, old))
           }
           oldChar = newchar
-          print(newchar)
         }
       }
     }
@@ -59,7 +59,6 @@ final class HeapTests: XCTestCase {
             XCTAssert(comparator(newValue, old))
           }
           oldValue = newValue
-          print(newValue)
         }
       }
     }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Added `Heap` to provide a comparator-based in-order view of a `Collection`. 

I know @rakaramos has been working on this with `PartialSort` and some other things that are more in line with the
evolution process. So this is kind of a foul but I put this together to scratch an itch and wanted to sent the PR for people to look at. 

I used the `Permutations` code as a base. There's been some discussion of algorithms vs data structures in the forums. This is a weird one because it includes a data structure to support a partial sort algorithm. 

I'm also not sure if there is not a "currency type" hiding in there around the array of indexes that is also treated as a binary tree. C++ has some methods in `algorithm` that let you treat an array as a binary tree, and the heap algorithms do something like that. 

I put some other notes in `Guides/Heap.md` as well. There are still some to-dos at the top of `Heap.swift`. 

Thanks for looking at this! 


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
