### PR TITLE
Removes unnecessary shuffle from randomSample method of Collection and Sequence

### DIFF
--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -143,9 +143,7 @@ extension Collection {
         formIndex(after: &i)
       }
     }
-    
-    // FIXME: necessary?
-    result.shuffle(using: &rng)
+
     return result
   }
   

--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -211,9 +211,7 @@ extension Sequence {
       let j = Int.random(in: 0..<result.count, using: &rng)
       result[j] = nextElement
     }
-    
-    // FIXME: necessary?
-    result.shuffle(using: &rng)
+
     return result
   }
   


### PR DESCRIPTION
This PR removes unnecessary shuffle from `randomSample` method of Collection and Sequence. 
```swift
// FIXME: necessary?
result.shuffle(using: &rng)
```
Since randomSample method already Swap selected element with a randomly chosen one in the reservoir there is no need to do that extra shuffle for the reservoir. This was marked as `// FIXME` by removing it, `randomSample` still randomly selects the specified number of elements from this sequence, and the `RandomSampleTests` runs successfully.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
