### PR TITLE
Fix contribution guidelines link in PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,5 @@ Replace this paragraph with a description of your changes and rationale. Provide
 ### Checklist
 - [ ] I've added at least one test that validates that my change is working, if appropriate
 - [ ] I've followed the code style of the rest of the project
-- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
+- [ ] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
 - [ ] I've updated the documentation if necessary

--- a/.github/PULL_REQUEST_TEMPLATE/NEW.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW.md
@@ -34,5 +34,5 @@ What is the impact of this change on existing users? Does it deprecate or remove
 ### Checklist
 - [ ] I've added at least one test that validates that my change is working, if appropriate
 - [ ] I've followed the code style of the rest of the project
-- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
+- [ ] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
 - [ ] I've updated the documentation if necessary


### PR DESCRIPTION
This PR fix the path for contribution guidelines in PR templates.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
