### PR TITLE
Fix method name in Random Sampling guide

### DIFF
--- a/Guides/RandomSampling.md
+++ b/Guides/RandomSampling.md
@@ -95,7 +95,7 @@ unstable implementation of `randomSample` explicitly shuffles the elements
 before returning them. 
 
 To see the bias without shuffling, consider the following example that uses a
-hypothetical `randomElementsUnshuffled` method. When selecting three out of 
+hypothetical `randomSampleUnshuffled` method. When selecting three out of 
 four elements from an array, whenever any of the first three elements are 
 included in the result, they are always in their original positions. Elements 
 selected after the initial `count` are in randomly selected positions.
@@ -104,19 +104,19 @@ selected after the initial `count` are in randomly selected positions.
 // This shows the behavior WITHOUT post-sample shuffling.
 // Selecting 3/4 elements, there are only four possible outcomes:
 let source = [10, 20, 30, 40]
-source.randomElementsUnshuffled(count: 3)  // [10, 20, 30]
-source.randomElementsUnshuffled(count: 3)  // [40, 20, 30]
-source.randomElementsUnshuffled(count: 3)  // [10, 40, 30]
-source.randomElementsUnshuffled(count: 3)  // [10, 20, 40]
+source.randomSampleUnshuffled(count: 3)  // [10, 20, 30]
+source.randomSampleUnshuffled(count: 3)  // [40, 20, 30]
+source.randomSampleUnshuffled(count: 3)  // [10, 40, 30]
+source.randomSampleUnshuffled(count: 3)  // [10, 20, 40]
 ```
 
-The proposed `randomElements` method has no positional bias:
+The proposed `randomSample` method has no positional bias:
 
 ```swift
 // The current behavior shuffles the elements, erasing the bias:
 let source = [10, 20, 30, 40]
-source.randomElements(count: 3)  // [20, 30, 10]
-source.randomElements(count: 3)  // [40, 20, 30]
+source.randomSample(count: 3)  // [20, 30, 10]
+source.randomSample(count: 3)  // [40, 20, 30]
 // ...several more possible outcomes
 ```
 


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replaces usage of `randomElements` with `randomSample` in the Random Sampling guide.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
