### PR TITLE
Fix and improve `Chain`'s index offsetting logic

### DIFF
--- a/Sources/Algorithms/Chain.swift
+++ b/Sources/Algorithms/Chain.swift
@@ -149,7 +149,7 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
       } else {
         // The limit only has an effect here if it's "above" `i`
         if limit >= i {
-          return Index(first: limit)
+          return nil
         } else {
           return Index(
             second: base2.index(base2.startIndex, offsetBy: n - d))
@@ -193,7 +193,7 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
       if n <= d {
         return Index(second: base2.index(i, offsetBy: -n))
       } else {
-        return base1.index(base1.endIndex, offsetBy: -n - d, limitedBy: limit)
+        return base1.index(base1.endIndex, offsetBy: -(n - d), limitedBy: limit)
           .map(Index.init(first:))
       }
 
@@ -203,8 +203,12 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
         return base2.index(i, offsetBy: -n, limitedBy: limit)
           .map(Index.init(second:))
       } else {
-        return Index(
-          first: base1.index(base1.endIndex, offsetBy: -n - d))
+        // The limit only has an effect here if it's "below" `i`
+        if limit <= i {
+          return nil
+        } else {
+          return Index(first: base1.index(base1.endIndex, offsetBy: -(n - d)))
+        }
       }
     }
   }

--- a/Sources/Algorithms/Chain.swift
+++ b/Sources/Algorithms/Chain.swift
@@ -84,13 +84,17 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
       }
     }
   }
+  
+  /// Converts an index of `Base1` to the corresponding `Index` by mapping
+  /// `base1.endIndex` to `base2.startIndex`.
+  internal func convertIndex(_ i: Base1.Index) -> Index {
+    i == base1.endIndex ? Index(second: base2.startIndex) : Index(first: i)
+  }
 
   public var startIndex: Index {
-    // If `base1` is empty, then `base2.startIndex` is either a valid position
-    // of the first element in `base2` or equal to `base2.endIndex`.
-    return base1.isEmpty
-      ? Index(second: base2.startIndex)
-      : Index(first: base1.startIndex)
+    // if `base1` is empty, this will return `base2.startIndex` - if `base2` is
+    // also empty, this will correctly equal `base2.endIndex`
+    convertIndex(base1.startIndex)
   }
 
   public var endIndex: Index {
@@ -110,10 +114,7 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
     switch i.position {
     case let .first(i):
       assert(i != base1.endIndex)
-      let next = base1.index(after: i)
-      return next == base1.endIndex
-        ? Index(second: base2.startIndex)
-        : Index(first: next)
+      return convertIndex(base1.index(after: i))
     case let .second(i):
       return Index(second: base2.index(after: i))
     }
@@ -142,27 +143,27 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
   ) -> Index? {
     switch (i.position, limit.position) {
     case let (.first(i), .first(limit)):
-      let d = base1.distance(from: i, to: base1.endIndex)
-      if n < d {
+      if limit >= i {
+        // `limit` is relevant, so `base2` cannot be reached
         return base1.index(i, offsetBy: n, limitedBy: limit)
           .map(Index.init(first:))
+      } else if let j = base1.index(i, offsetBy: n, limitedBy: base1.endIndex) {
+        // the offset stays within the bounds of `base1`
+        return convertIndex(j)
       } else {
-        // The limit only has an effect here if it's "above" `i`
-        if limit >= i {
-          return nil
-        } else {
-          return Index(
-            second: base2.index(base2.startIndex, offsetBy: n - d))
-        }
+        // the offset overflows the bounds of `base1` by `n - d`
+        let d = base1.distance(from: i, to: base1.endIndex)
+        return Index(second: base2.index(base2.startIndex, offsetBy: n - d))
       }
     
     case let (.first(i), .second(limit)):
-      let d = base1.distance(from: i, to: base1.endIndex)
-      if n < d {
-        return Index(first: base1.index(i, offsetBy: n))
+      if let j = base1.index(i, offsetBy: n, limitedBy: base1.endIndex) {
+        // the offset stays within the bounds of `base1`
+        return convertIndex(j)
       } else {
-        return base2.index(
-          base2.startIndex, offsetBy: n - d, limitedBy: limit)
+        // the offset overflows the bounds of `base1` by `n - d`
+        let d = base1.distance(from: i, to: base1.endIndex)
+        return base2.index(base2.startIndex, offsetBy: n - d, limitedBy: limit)
           .map(Index.init(second:))
       }
       
@@ -189,26 +190,28 @@ extension Chain: Collection where Base1: Collection, Base2: Collection {
       return Index(first: base1.index(i, offsetBy: -n))
       
     case let (.second(i), .first(limit)):
-      let d = base2.distance(from: base2.startIndex, to: i)
-      if n <= d {
-        return Index(second: base2.index(i, offsetBy: -n))
+      if let j = base2.index(i, offsetBy: -n, limitedBy: base2.startIndex) {
+        // the offset stays within the bounds of `base2`
+        return Index(second: j)
       } else {
+        // the offset overflows the bounds of `base2` by `n - d`
+        let d = base2.distance(from: base2.startIndex, to: i)
         return base1.index(base1.endIndex, offsetBy: -(n - d), limitedBy: limit)
           .map(Index.init(first:))
       }
 
     case let (.second(i), .second(limit)):
-      let d = base2.distance(from: base2.startIndex, to: i)
-      if n <= d {
+      if limit <= i {
+        // `limit` is relevant, so `base1` cannot be reached
         return base2.index(i, offsetBy: -n, limitedBy: limit)
           .map(Index.init(second:))
+      } else if let j = base2.index(i, offsetBy: -n, limitedBy: base2.startIndex) {
+        // the offset stays within the bounds of `base2`
+        return Index(second: j)
       } else {
-        // The limit only has an effect here if it's "below" `i`
-        if limit <= i {
-          return nil
-        } else {
-          return Index(first: base1.index(base1.endIndex, offsetBy: -(n - d)))
-        }
+        // the offset overflows the bounds of `base2` by `n - d`
+        let d = base2.distance(from: base2.startIndex, to: i)
+        return Index(first: base1.index(base1.endIndex, offsetBy: -(n - d)))
       }
     }
   }

--- a/Tests/SwiftAlgorithmsTests/ChainTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChainTests.swift
@@ -43,7 +43,84 @@ final class ChainTests: XCTestCase {
     XCTAssertEqualSequences(s1.reversed().chained(with: s2), "JIHGFEDCBAklmnopqrstuv")
   }
   
-  // TODO: Add tests that check index(offsetBy:)
+  func testChainIndexOffsetBy() {
+    let s1 = "abcde"
+    let s2 = "VWXYZ"
+    let chain = s1.chained(with: s2)
+    
+    for (startOffset, endOffset) in product(0...chain.count, 0...chain.count) {
+      let start = index(atOffset: startOffset, in: chain)
+      let end = index(atOffset: endOffset, in: chain)
+      let distance = endOffset - startOffset
+      XCTAssertEqual(chain.index(start, offsetBy: distance), end)
+    }
+  }
+  
+  func testChainIndexOffsetByLimitedBy() {
+    let s1 = "abcd"
+    let s2 = "XYZ"
+    let chain = s1.chained(with: s2)
+    
+    for (startOffset, limitOffset) in product(0...chain.count, 0...chain.count) {
+      let start = index(atOffset: startOffset, in: chain)
+      let limit = index(atOffset: limitOffset, in: chain)
+      
+      // verifies that the target index corresponding to each offset in `range`
+      // can or cannot be reached from `start` using
+      // `chain.index(start, offsetBy: _, limitedBy: limit)`, depending on the
+      // value of `beyondLimit`
+      func checkTargetRange(_ range: ClosedRange<Int>, beyondLimit: Bool) {
+        for targetOffset in range {
+          let distance = targetOffset - startOffset
+          
+          XCTAssertEqual(
+            chain.index(start, offsetBy: distance, limitedBy: limit),
+            beyondLimit ? nil : index(atOffset: targetOffset, in: chain))
+        }
+      }
+      
+      // forward
+      if limit >= start {
+        // the limit has an effect
+        checkTargetRange(startOffset...limitOffset, beyondLimit: false)
+        checkTargetRange((limitOffset + 1)...(chain.count + 1), beyondLimit: true)
+      } else {
+        // the limit has no effect
+        checkTargetRange(startOffset...chain.count, beyondLimit: false)
+      }
+      
+      // backward
+      if limit <= start {
+        // the limit has an effect
+        checkTargetRange(limitOffset...startOffset, beyondLimit: false)
+        checkTargetRange(-1...(limitOffset - 1), beyondLimit: true)
+      } else {
+        // the limit has no effect
+        checkTargetRange(0...startOffset, beyondLimit: false)
+      }
+    }
+  }
+  
+  func testChainIndexOffsetAcrossBoundary() {
+    let chain = "abc".chained(with: "XYZ")
+    
+    do {
+      let i = chain.index(chain.startIndex, offsetBy: 3, limitedBy: chain.startIndex)
+      XCTAssertNil(i)
+    }
+    
+    do {
+      let i = chain.index(chain.startIndex, offsetBy: 4)
+      let j = chain.index(i, offsetBy: -2)
+      XCTAssertEqual(chain[j], "c")
+    }
+    
+    do {
+      let i = chain.index(chain.startIndex, offsetBy: 3)
+      let j = chain.index(i, offsetBy: -1, limitedBy: i)
+      XCTAssertNil(j)
+    }
+  }
   
   func testChainDistanceFromTo() {
     let s1 = "abcde"


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

`Chain`'s index offsetting logic is untested and contains a few bugs, all these assertions fail:

```swift
let chain = "abc".chained(with: "XYZ")

do {
  let i = chain.index(chain.startIndex, offsetBy: 3, limitedBy: chain.startIndex)
  XCTAssertNil(i)
}

do {
  let i = chain.index(chain.startIndex, offsetBy: 4)
  let j = chain.index(i, offsetBy: -2)
  XCTAssertEqual(chain[j], "c")
}

do {
  let i = chain.index(chain.startIndex, offsetBy: 3)
  let j = chain.index(i, offsetBy: -1, limitedBy: i)
  XCTAssertNil(j)
}
```

I've put the fixes for these in a separate commit for reference.

Another issue with the current implementation is that `chain.index(i, offsetBy: n)` (with `i` pointing into `base1`) always computes the distance from `i` to `base1.endIndex`, regardless of `n`. As a result, this code traverses the entire string:
```swift
let chain = someVeryLongString().chained(with: [])
let n = someVerySmallNumber()
let _ = chain.index(chain.startIndex, offsetBy: n)
```

This PR fixes this by first calling `base1.index(i, offsetBy: n, limitedBy: base1.endIndex)` before potentially computing the distance to `base1.endIndex`.

This does still mean that when crossing the boundary between `base1` and `base2`, the suffix of `base1` is traversed twice. If we could determine whether or not `Base1: RandomAccessCollection` then we could conditionally replace this logic by repeated `base1.index(after:)` calls, but I'm not sure if that's possible...

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
