### PR TITLE
Fix `Product2`'s indexing logic

### DIFF
--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -120,7 +120,7 @@ extension Product2: Collection where Base1: Collection {
     }
     
     return base2[start.i2...].count + base2[..<end.i2].count
-      + base2.count * (base1.distance(from: start.i1, to: end.i1))
+      + base2.count * (base1.distance(from: start.i1, to: end.i1) - 1)
   }
 
   public subscript(position: Index) -> (Base1.Element, Base2.Element) {

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -135,12 +135,12 @@ extension Product2: BidirectionalCollection
     precondition(i != startIndex,
                  "Can't move before startIndex")
     if i.i2 == base2.startIndex {
+      return Index(
+        i1: base1.index(before: i.i1),
+        i2: base2.index(before: base2.endIndex))
+    } else {
       return Index(i1: i.i1, i2: base2.index(before: i.i2))
     }
-    
-    return Index(
-      i1: base1.index(before: i.i1),
-      i2: base2.index(before: base2.endIndex))
   }
 }
 

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -91,27 +91,22 @@ extension Product2: Collection where Base1: Collection {
   }
   
   public var startIndex: Index {
-    base1.isEmpty || base2.isEmpty
-      ? endIndex
-      : Index(i1: base1.startIndex, i2: base2.startIndex)
+    Index(
+      i1: base2.isEmpty ? base1.endIndex : base1.startIndex,
+      i2: base2.startIndex)
   }
   
   public var endIndex: Index {
-    Index(i1: base1.endIndex, i2: base2.endIndex)
+    // this representation makes index calculations simpler
+    Index(i1: base1.endIndex, i2: base2.startIndex)
   }
   
   public func index(after i: Index) -> Index {
-    precondition(i.i1 != base1.endIndex && i.i2 != base2.endIndex,
-                 "Can't advance past endIndex")
+    precondition(i.i1 != base1.endIndex, "Can't advance past endIndex")
     let newIndex2 = base2.index(after: i.i2)
-    if newIndex2 < base2.endIndex {
-      return Index(i1: i.i1, i2: newIndex2)
-    }
-    
-    let newIndex1 = base1.index(after: i.i1)
-    return newIndex1 == base1.endIndex
-      ? endIndex
-      : Index(i1: newIndex1, i2: base2.startIndex)
+    return newIndex2 == base2.endIndex
+      ? Index(i1: base1.index(after: i.i1), i2: base2.startIndex)
+      : Index(i1: i.i1, i2: newIndex2)
   }
   
   // TODO: Implement index(_:offsetBy:) and index(_:offsetBy:limitedBy:)

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -97,7 +97,7 @@ extension Product2: Collection where Base1: Collection {
   }
   
   public var endIndex: Index {
-    // this representation makes index calculations simpler
+    // `base2.startIndex` simplifies index calculations.
     Index(i1: base1.endIndex, i2: base2.startIndex)
   }
   

--- a/Tests/SwiftAlgorithmsTests/ProductTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ProductTests.swift
@@ -22,4 +22,14 @@ final class ProductTests: XCTestCase {
     XCTAssertEqualSequences(product(1...10, ""), [], by: ==)
     XCTAssertEqualSequences(product("", 1...10), [], by: ==)
   }
+  
+  func testProductReversed() {
+    XCTAssertEqualSequences(
+      [(2, "B" as Character), (2, "A"), (1, "B"), (1, "A")],
+      product(1...2, "AB").reversed(),
+      by: ==)
+
+    XCTAssertEqualSequences(product(1...10, "").reversed(), [], by: ==)
+    XCTAssertEqualSequences(product("", 1...10).reversed(), [], by: ==)
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/ProductTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ProductTests.swift
@@ -32,4 +32,9 @@ final class ProductTests: XCTestCase {
     XCTAssertEqualSequences(product(1...10, "").reversed(), [], by: ==)
     XCTAssertEqualSequences(product("", 1...10).reversed(), [], by: ==)
   }
+  
+  func testProductDistanceFromTo() {
+    let p = product([1, 2], "abc")
+    XCTAssertEqual(p.distance(from: p.startIndex, to: p.endIndex), 6)
+  }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR changes the way `Product2.endIndex` is represented: instead of `(base1.endIndex, base2.endIndex)`, it is now `(base1.endIndex, base2.startIndex)`.

The latter turns out to be a more natural way of representing the "past the end" index because it is exactly the index after the last valid index `(lastValidIndexOfBase1, lastValidIndexOfBase2)` according to the existing mechanism of advancing any other index of `Product2`. As a result, the methods `index(before:)`, `index(after:)`, and `distance(from:to:)` don't need any custom logic to deal with `endIndex`.

`endIndex` wasn't handled correctly everywhere so this also ends up fixing bugs in `index(before:)` and `distance(from:to:)`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
