### PR TITLE
Add the magic plist file to make xcode render the markdown guides.

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
The downside to doing this is that it makes the files more inconvenient to edit, since Xcode doesn't let you toggle out of the rendered view easily, but I think it makes sense on the premise that these are read much more often than edited. I have this flag set in Swift Numerics for this reason.