### PR TITLE
Add conditional LazySequenceProtocol conformance

### DIFF
--- a/Guides/Chain.md
+++ b/Guides/Chain.md
@@ -29,12 +29,12 @@ extension Sequence {
     public func chained<S: Sequence>(with other: S) -> Concatenation<Self, S>
         where Element == S.Element
 }
-
 ```
 
-The resulting `Chain` type is a sequence, with conditional conformance to the
-`Collection`, `BidirectionalCollection`, and `RandomAccessCollection`  when both
-the first and second arguments conform.
+The resulting `Chain` type is a sequence, with conditional conformance to
+`Collection`, `BidirectionalCollection`, and `RandomAccessCollection` when both
+the first and second arguments conform. `Chain` also conforms to
+`LazySequenceProtocol` when the first argument conforms.
 
 ### Naming
 

--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -51,7 +51,8 @@ Since the `Combinations` type needs to store an array of the collection’s
 indices and mutate the array to generate each permutation, `Combinations` only
 has `Sequence` conformance. Adding `Collection` conformance would require
 storing the array in the index type, which would in turn lead to copying the
-array at every index advancement.
+array at every index advancement. `Combinations` does conform to
+`LazySequenceProtocol` when the base type conforms.
 
 ### Complexity
 

--- a/Guides/Cycle.md
+++ b/Guides/Cycle.md
@@ -33,10 +33,12 @@ extension Collection {
 ```
 
 The new `Cycle` type is a sequence only, given that the `Collection` protocol
-design makes infinitely large types impossible/impractical. Note that despite
-its name, the returned `FlattenSequence` will always have `Collection`
-conformance, and will have `BidirectionalCollection` conformance when called on
-a bidirectional collection.
+design makes infinitely large types impossible/impractical. `Cycle` also
+conforms to `LazySequenceProtocol` when the base type conforms.
+
+Note that despite its name, the returned `FlattenSequence` will always have
+`Collection` conformance, and will have `BidirectionalCollection` conformance
+when called on a bidirectional collection.
 
 ### Complexity
 

--- a/Guides/Indexed.md
+++ b/Guides/Indexed.md
@@ -30,5 +30,6 @@ extension Collection {
 ```
 
 `Indexed` scales from a collection up to a random-access collection, depending on 
-its base type.
+its base type. `Indexed` also conforms to `LazySequenceProtocol` when the base type
+conforms.
 

--- a/Guides/Permutations.md
+++ b/Guides/Permutations.md
@@ -75,7 +75,8 @@ Since the `Permutations` type needs to store an array of the collection’s
 indices and mutate the array to generate each permutation, `Permutations` only
 has `Sequence` conformance. Adding `Collection` conformance would require
 storing the array in the index type, which would in turn lead to copying the
-array at every index advancement.
+array at every index advancement. `Combinations` does conform to
+`LazySequenceProtocol` when the base type conforms.
 
 ### Complexity
 

--- a/Sources/Algorithms/Chain.swift
+++ b/Sources/Algorithms/Chain.swift
@@ -250,6 +250,7 @@ extension Chain: BidirectionalCollection
 
 extension Chain: RandomAccessCollection
   where Base1: RandomAccessCollection, Base2: RandomAccessCollection {}
+extension Chain: LazySequenceProtocol where Base1: LazySequenceProtocol {}
 
 extension Chain: Equatable where Base1: Equatable, Base2: Equatable {}
 extension Chain: Hashable where Base1: Hashable, Base2: Hashable {}

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -111,6 +111,7 @@ extension Combinations: Sequence {
   }
 }
 
+extension Combinations: LazySequenceProtocol where Base: LazySequenceProtocol {}
 extension Combinations: Equatable where Base: Equatable {}
 extension Combinations: Hashable where Base: Hashable {}
 

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -38,6 +38,8 @@ extension Cycle: Sequence {
   }
 }
 
+extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
+
 //===----------------------------------------------------------------------===//
 // cycled()
 //===----------------------------------------------------------------------===//
@@ -71,13 +73,7 @@ extension Collection {
   public func cycled() -> Cycle<Self> {
     Cycle(base: self)
   }
-}
-
-//===----------------------------------------------------------------------===//
-// repeated(count:)
-//===----------------------------------------------------------------------===//
-
-extension Collection {
+  
   /// Returns a sequence that repeats the elements of this collection the
   /// specified number of times.
   ///

--- a/Sources/Algorithms/Indexed.swift
+++ b/Sources/Algorithms/Indexed.swift
@@ -56,8 +56,13 @@ extension Indexed: BidirectionalCollection where Base: BidirectionalCollection {
 }
 
 extension Indexed: RandomAccessCollection where Base: RandomAccessCollection {}
+extension Indexed: LazySequenceProtocol where Base: LazySequenceProtocol {}
 extension Indexed: Equatable where Base: Equatable {}
 extension Indexed: Hashable where Base: Hashable {}
+
+//===----------------------------------------------------------------------===//
+// indexed()
+//===----------------------------------------------------------------------===//
 
 extension Collection {
   /// Returns a collection of pairs *(i, x)*, where *i* represents an index of

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -129,6 +129,8 @@ extension Permutations: Sequence {
   }
 }
 
+extension Permutations: LazySequenceProtocol where Base: LazySequenceProtocol {}
+
 //===----------------------------------------------------------------------===//
 // nextPermutation(by:)
 //===----------------------------------------------------------------------===//
@@ -177,7 +179,7 @@ extension MutableCollection
 }
 
 //===----------------------------------------------------------------------===//
-// permutations(count:)
+// permutations(ofCount:)
 //===----------------------------------------------------------------------===//
 
 extension Collection {

--- a/Tests/SwiftAlgorithmsTests/ChainTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChainTests.swift
@@ -136,4 +136,8 @@ final class ChainTests: XCTestCase {
       XCTAssertEqual(chain.distance(from: start, to: end), distance)
     }
   }
+  
+  func testChainLazy() {
+    XCTAssertLazy([1, 2, 3].lazy.chained(with: [4, 5, 6]))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -71,4 +71,9 @@ final class ChunkedTests: XCTestCase {
     let lazyChunks = fruits.lazy.chunked(by: { $0.first == $1.first })
     validateFruitChunks(lazyChunks)
   }
+  
+  func testChunkedLazy() {
+    XCTAssertLazy(fruits.lazy.chunked(by: { $0.first == $1.first }))
+    XCTAssertLazy(fruits.lazy.chunked(on: { $0.first }))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -38,4 +38,8 @@ final class CombinationsTests: XCTestCase {
     XCTAssertEqualSequences([], "".combinations(ofCount: 5))
     XCTAssertEqualSequences([], "ABCD".combinations(ofCount: 5))
   }
+  
+  func testCombinationsLazy() {
+    XCTAssertLazy("ABC".lazy.combinations(ofCount: 1))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/CycleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CycleTests.swift
@@ -39,4 +39,8 @@ final class CycleTests: XCTestCase {
     let empty2 = Array("Hello".cycled(times: 0))
     XCTAssert(empty2.isEmpty)
   }
+  
+  func testCycleLazy() {
+    XCTAssertLazy((1...4).lazy.cycled())
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/IndexedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IndexedTests.swift
@@ -27,4 +27,8 @@ final class IndexedTests: XCTestCase {
     let indexOfI = si.last(where: { $0.element == "I" })!.index
     XCTAssertEqual("I", s[indexOfI])
   }
+  
+  func testIndexedLazy() {
+    XCTAssertLazy("ABCD".lazy.indexed())
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
@@ -69,4 +69,8 @@ final class PermutationsTests: XCTestCase {
     while numbers.nextPermutation() {}
     XCTAssertEqual([1, 2, 3, 4, 5, 6, 7], numbers)
   }
+  
+  func testPermutationsLazy() {
+    XCTAssertLazy("ABCD".lazy.permutations(ofCount: 2))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -65,3 +65,4 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
   try XCTAssert(expression1().elementsEqual(expression2(), by: areEquivalent), message(), file: file, line: line)
 }
 
+func XCTAssertLazy<S: LazySequenceProtocol>(_: S) {}


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This adds overloads to `LazySequenceProtocol` of existing lazy-by-default sequence algorithms, for the sole purpose of keeping lazy chains lazy when one of these methods is called.

`uniqued` is left out of this because it (currently) isn't lazy to begin with. A `LazySequenceProtocol` overload will only make sense once we have a `Uniqued` sequence that produces unique elements on demand.

Two unresolved questions:
- Do we want all of these overloads? I've added them for all algorithms that have a `self` and return a new sequence/collection, but that might be too lenient. (Is there a guideline for this somewhere?)
- Should the guides mention these overloads, given that they don't add any actual functionality? The Chunked guide mentions them, but then again `lazy.chunked` and `.chunked.lazy` are entirely different things, unlike the ones I'm adding here. Mentioning them in a more general document such as the README is another option.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
