### PR TITLE
Fix stablePartition(subrange:by:) using subrange count instead of entire collection count.

### DIFF
--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -61,7 +61,7 @@ extension MutableCollection {
     by belongsInSecondPartition: (Element) throws-> Bool
   ) rethrows -> Index {
     try stablePartition(
-      count: count,
+      count: self[subrange].count,
       subrange: subrange,
       by: belongsInSecondPartition)
   }

--- a/Tests/SwiftAlgorithmsTests/PartitionTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PartitionTests.swift
@@ -61,6 +61,21 @@ final class PartitionTests: XCTestCase {
     }
   }
   
+  func testStablePartitionWithSubrange() {
+    for length in 10...20 {
+      let a = Array(0..<length)
+      for j in 0..<length {
+        var b = a
+        let partitionRange = 0..<j
+        let condition = { $0 < j - 1 }
+        let p = b.stablePartition(subrange: partitionRange, by: condition)
+        XCTAssertEqual(p, partitionRange.count > 0 ? 1 : 0)
+        XCTAssertEqualSequences(b[partitionRange.lowerBound..<p], a[partitionRange].filter { !condition($0) })
+        XCTAssertEqualSequences(b[p..<partitionRange.upperBound], a[partitionRange].filter(condition))
+      }
+    }
+  }
+  
   func testPartitioningIndex() {
     for i in 0..<7 {
       for j in i..<11 {


### PR DESCRIPTION
Function `stablePartition(subrange:by:)` in `Partition` should not using the collection count which will cause bound error, but using subrange count.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
