### PR TITLE
Add interspersed(with:)

### DIFF
--- a/Guides/Intersperse.md
+++ b/Guides/Intersperse.md
@@ -1,0 +1,55 @@
+# Intersperse
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Intersperse.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/IntersperseTests.swift)]
+
+Place a given value in between each element of the sequence.
+
+```swift
+let numbers = [1, 2, 3].interspersed(with: 0)
+// Array(numbers) == [1, 0, 2, 0, 3]
+
+let letters = "ABCDE".interspersed(with: "-")
+// String(letters) == "A-B-C-D-E"
+
+let empty = [].interspersed(with: 0)
+// Array(empty) == []
+```
+
+`interspersed(with:)` takes a separator value and inserts it in between every
+element in the sequence.
+
+## Detailed Design
+
+A new method is added to sequence:
+
+```swift
+extension Sequence {
+    func interspersed(with separator: Element) -> Intersperse<Self>
+}
+```
+
+The new `Intersperse` type represents the sequence when the separator is
+inserted between each element.
+
+### Complexity
+
+Calling these methods is O(_1_).
+
+### Naming
+
+This method’s and type’s name match the term of art used in other languages
+and libraries.
+
+### Comparison with other languages
+
+**[Haskell][Haskell]:** Has an `intersperse` function which takes an element
+and a list and 'intersperses' that element between the elements of the list.
+
+**[Rust][Rust]:** Has a function called `intersperse` to insert a particular
+value between each element. 
+
+<!-- Link references for other languages -->
+
+[Haskell]: https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#v:intersperse
+[Rust]: https://docs.rs/itertools/0.9.0/itertools/trait.Itertools.html#method.intersperse

--- a/Guides/Intersperse.md
+++ b/Guides/Intersperse.md
@@ -30,7 +30,8 @@ extension Sequence {
 ```
 
 The new `Intersperse` type represents the sequence when the separator is
-inserted between each element.
+inserted between each element. It conforms to Collection when the underlying
+sequence conforms to Collection.
 
 ### Complexity
 

--- a/Guides/Intersperse.md
+++ b/Guides/Intersperse.md
@@ -30,8 +30,9 @@ extension Sequence {
 ```
 
 The new `Intersperse` type represents the sequence when the separator is
-inserted between each element. It conforms to Collection when the underlying
-sequence conforms to Collection.
+inserted between each element. Intersperse conforms to Collection and 
+BidirectionalCollection when the base sequence conforms to Collection and
+BidirectionalCollection respectively.
 
 ### Complexity
 

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -54,6 +54,50 @@ extension Intersperse: Sequence {
   }
 }
 
+extension Intersperse: Collection where Base: Collection {
+  public struct Index: Comparable {
+    enum Kind {
+      case element
+      case separator
+    }
+    let index: Base.Index
+    let kind: Kind
+
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      if lhs.index < rhs.index { return true }
+      if lhs.index > rhs.index { return false }
+      if lhs.kind == .element, rhs.kind == .separator { return true }
+      return false
+    }
+  }
+
+  public var startIndex: Index {
+    Index(index: base.startIndex, kind: .element)
+  }
+
+  public var endIndex: Index {
+    Index(index: base.endIndex, kind: .element)
+  }
+
+  public func index(after i: Index) -> Index {
+    switch i.kind {
+    case .element where base.index(after: i.index) == base.endIndex:
+      return endIndex
+    case .element:
+      return Index(index: i.index, kind: .separator)
+    case .separator:
+      return Index(index: base.index(after: i.index), kind: .element)
+    }
+  }
+
+  public subscript(position: Index) -> Element {
+    switch position.kind {
+    case .element: return base[position.index]
+    case .separator: return separator
+    }
+  }
+}
+
 extension Sequence {
 
   /// Returns a sequence containing elements of this sequence with the given

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -137,6 +137,9 @@ extension Intersperse: BidirectionalCollection
   }
 }
 
+extension Intersperse: RandomAccessCollection
+  where Base: RandomAccessCollection {}
+
 extension Sequence {
 
   /// Returns a sequence containing elements of this sequence with the given

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -56,14 +56,21 @@ extension Intersperse: Sequence {
 
 extension Intersperse: Collection where Base: Collection {
   public struct Index: Comparable {
-    enum Representation: Comparable {
+    enum Representation: Equatable {
       case element(Base.Index)
       case separator(next: Base.Index)
     }
     let representation: Representation
 
     public static func < (lhs: Index, rhs: Index) -> Bool {
-      lhs.representation < rhs.representation
+      switch (lhs.representation, rhs.representation) {
+      case let (.element(li), .element(ri)),
+           let (.separator(next: li), .separator(next: ri)),
+           let (.element(li), .separator(next: ri)):
+        return li < ri
+      case let (.separator(next: li), .element(ri)):
+        return li <= ri
+      }
     }
 
     static func element(_ index: Base.Index) -> Self {

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -56,7 +56,7 @@ extension Intersperse: Sequence {
 
 extension Intersperse: Collection where Base: Collection {
   public struct Index: Comparable {
-    enum Kind {
+    enum Kind: Comparable {
       case element
       case separator
     }
@@ -64,10 +64,7 @@ extension Intersperse: Collection where Base: Collection {
     let kind: Kind
 
     public static func < (lhs: Index, rhs: Index) -> Bool {
-      if lhs.index < rhs.index { return true }
-      if lhs.index > rhs.index { return false }
-      if lhs.kind == .element, rhs.kind == .separator { return true }
-      return false
+      (lhs.index, lhs.kind) < (rhs.index, rhs.kind)
     }
   }
 

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -106,6 +106,20 @@ extension Intersperse: Collection where Base: Collection {
     case .separator: return separator
     }
   }
+
+  public func distance(from start: Index, to end: Index) -> Int {
+    switch (start.representation, end.representation) {
+    case let (.element(lhs), .separator(next: rhs)),
+         let (.element(lhs), .element(rhs)) where rhs == base.endIndex:
+      return (2 * base.distance(from: lhs, to: rhs)) - 1
+    case let (.element(lhs), .element(rhs)),
+         let (.separator(lhs), .separator(rhs)),
+         let (.separator(next: lhs), .element(rhs)) where rhs == base.endIndex:
+      return 2 * base.distance(from: lhs, to: rhs)
+    case let (.separator(next: lhs), .element(rhs)):
+      return (2 * base.distance(from: lhs, to: rhs)) + 1
+    }
+  }
 }
 
 extension Intersperse: BidirectionalCollection

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -65,25 +65,31 @@ extension Intersperse: Collection where Base: Collection {
     public static func < (lhs: Index, rhs: Index) -> Bool {
       lhs.representation < rhs.representation
     }
+
+    static func element(_ index: Base.Index) -> Self {
+      Self(representation: .element(index))
+    }
+
+    static func separator(next: Base.Index) -> Self {
+      Self(representation: .separator(next: next))
+    }
   }
 
   public var startIndex: Index {
-    Index(representation: .element(base.startIndex))
+    .element(base.startIndex)
   }
 
   public var endIndex: Index {
-    Index(representation: .element(base.endIndex))
+    .element(base.endIndex)
   }
 
   public func index(after i: Index) -> Index {
     switch i.representation {
     case let .element(index):
       let next = base.index(after: index)
-      return next == base.endIndex
-        ? endIndex
-        : Index(representation: .separator(next: next))
+      return next == base.endIndex ? endIndex : .separator(next: next)
     case let .separator(next):
-      return Index(representation: .element(next))
+      return .element(next)
     }
   }
 
@@ -101,11 +107,11 @@ extension Intersperse: BidirectionalCollection
   public func index(before i: Index) -> Index {
     switch i.representation {
     case let .element(index) where index == base.endIndex:
-      return Index(representation: .element(base.index(before: index)))
+      return .element(base.index(before: index))
     case let .element(index):
-      return Index(representation: .separator(next: index))
+      return .separator(next: index)
     case let .separator(next):
-      return Index(representation: .element(base.index(before: next)))
+      return .element(base.index(before: next))
     }
   }
 }

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -91,6 +91,7 @@ extension Intersperse: Collection where Base: Collection {
   }
 
   public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Can't advance past endIndex")
     switch i.representation {
     case let .element(index):
       return .separator(next: base.index(after: index))
@@ -138,6 +139,7 @@ extension Intersperse: BidirectionalCollection
   where Base: BidirectionalCollection
 {
   public func index(before i: Index) -> Index {
+    precondition(i != startIndex, "Can't move before startIndex")
     switch i.representation {
     case let .element(index):
       return .separator(next: index)

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -56,41 +56,40 @@ extension Intersperse: Sequence {
 
 extension Intersperse: Collection where Base: Collection {
   public struct Index: Comparable {
-    enum Kind: Comparable {
-      case element
+    enum Representation: Comparable {
+      case element(Base.Index)
       case separator(next: Base.Index)
     }
-    let index: Base.Index
-    let kind: Kind
+    let representation: Representation
 
     public static func < (lhs: Index, rhs: Index) -> Bool {
-      (lhs.index, lhs.kind) < (rhs.index, rhs.kind)
+      lhs.representation < rhs.representation
     }
   }
 
   public var startIndex: Index {
-    Index(index: base.startIndex, kind: .element)
+    Index(representation: .element(base.startIndex))
   }
 
   public var endIndex: Index {
-    Index(index: base.endIndex, kind: .element)
+    Index(representation: .element(base.endIndex))
   }
 
   public func index(after i: Index) -> Index {
-    switch i.kind {
-    case .element:
-      let next = base.index(after: i.index)
+    switch i.representation {
+    case let .element(index):
+      let next = base.index(after: index)
       return next == base.endIndex
         ? endIndex
-        : Index(index: i.index, kind: .separator(next: next))
-    case .separator(let next):
-      return Index(index: next, kind: .element)
+        : Index(representation: .separator(next: next))
+    case let .separator(next):
+      return Index(representation: .element(next))
     }
   }
 
   public subscript(position: Index) -> Element {
-    switch position.kind {
-    case .element: return base[position.index]
+    switch position.representation {
+    case .element(let index): return base[index]
     case .separator: return separator
     }
   }
@@ -100,13 +99,13 @@ extension Intersperse: BidirectionalCollection
   where Base: BidirectionalCollection
 {
   public func index(before i: Index) -> Index {
-    switch i.kind {
-    case .element where i.index == base.endIndex:
-      return Index(index: base.index(before: i.index), kind: .element)
-    case .element:
-      return Index(index: base.index(before: i.index), kind: .separator(next: i.index))
-    case .separator:
-      return Index(index: i.index, kind: .element)
+    switch i.representation {
+    case let .element(index) where index == base.endIndex:
+      return Index(representation: .element(base.index(before: index)))
+    case let .element(index):
+      return Index(representation: .separator(next: index))
+    case let .separator(next):
+      return Index(representation: .element(base.index(before: next)))
     }
   }
 }

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -98,6 +98,21 @@ extension Intersperse: Collection where Base: Collection {
   }
 }
 
+extension Intersperse: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  public func index(before i: Index) -> Index {
+    switch i.kind {
+    case .element where i.index == base.endIndex:
+      return Index(index: base.index(before: i.index), kind: .element)
+    case .element:
+      return Index(index: base.index(before: i.index), kind: .separator)
+    case .separator:
+      return Index(index: i.index, kind: .element)
+    }
+  }
+}
+
 extension Sequence {
 
   /// Returns a sequence containing elements of this sequence with the given

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A sequence that presents the elements of a base sequence of elements
+/// with a separator between each of those elements.
+public struct Intersperse<Base: Sequence> {
+  let base: Base
+  let separator: Base.Element
+}
+
+extension Intersperse: Sequence {
+  /// The iterator for an `Intersperse` sequence.
+  public struct Iterator: IteratorProtocol {
+    var iterator: Base.Iterator
+    let separator: Base.Element
+    var state = State.start
+
+    enum State {
+      case start
+      case element(Base.Element)
+      case separator
+    }
+
+    public mutating func next() -> Base.Element? {
+      // After the start, the state flips between element and separator. Before
+      // returning a separator, a check is made for the next element as a
+      // separator is only returned between two elements. The next element is
+      // stored to allow it to be returned in the next iteration.
+      switch state {
+      case .start:
+        state = .separator
+        return iterator.next()
+      case .separator:
+        guard let next = iterator.next() else { return nil }
+        state = .element(next)
+        return separator
+      case .element(let element):
+        state = .separator
+        return element
+      }
+    }
+  }
+
+  public func makeIterator() -> Intersperse<Base>.Iterator {
+    Iterator(iterator: base.makeIterator(), separator: separator)
+  }
+}
+
+extension Sequence {
+
+  /// Returns a sequence containing elements of this sequence with the given
+  /// separator inserted in between each element.
+  ///
+  /// Any value of the sequence's element type can be used as the separator.
+  ///
+  /// ```
+  /// for value in [1,2,3].interspersed(with: 0) {
+  ///     print(value)
+  /// }
+  /// // 1
+  /// // 0
+  /// // 2
+  /// // 0
+  /// // 3
+  /// ```
+  ///
+  /// The following shows a String being interspersed with a Character:
+  /// ```
+  /// let result = "ABCDE".interspersed(with: "-")
+  /// print(String(result))
+  /// // "A-B-C-D-E"
+  /// ```
+  ///
+  /// - Parameter separator: Value to insert in between each of this sequence’s
+  ///   elements.
+  /// - Returns: The interspersed sequence of elements.
+  ///
+  /// - Complexity: O(1)
+  public func interspersed(with separator: Element) -> Intersperse<Self> {
+    Intersperse(base: self, separator: separator)
+  }
+}

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -107,6 +107,29 @@ extension Intersperse: Collection where Base: Collection {
     }
   }
 
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    switch (i.representation, distance.isMultiple(of: 2)) {
+    case (_, _) where distance == 0:
+      return i
+    case (.element(base.endIndex), true):
+      return .separator(next: base.index(base.endIndex, offsetBy: distance / 2))
+    case (.element(base.endIndex), false):
+      return .element(base.index(base.endIndex, offsetBy: (distance - 1) / 2))
+    case (let .element(index), true):
+      return .element(base.index(index, offsetBy: distance / 2))
+    case (let .element(index), false):
+      let index = base.index(index, offsetBy: (distance + 1) / 2)
+      return index == base.endIndex ? endIndex : .separator(next: index)
+    case (let .separator(next: index), true):
+      let index = base.index(index, offsetBy: distance / 2)
+      return index == base.endIndex ? endIndex : .separator(next: index)
+    case (let .separator(next: index), false):
+      return .element(base.index(index, offsetBy: (distance - 1) / 2))
+    }
+  }
+
+  // TODO: Implement index(_:offsetBy:limitedBy:)
+
   public func distance(from start: Index, to end: Index) -> Int {
     switch (start.representation, end.representation) {
     // Handling endIndex

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -58,7 +58,7 @@ extension Intersperse: Collection where Base: Collection {
   public struct Index: Comparable {
     enum Kind: Comparable {
       case element
-      case separator
+      case separator(next: Base.Index)
     }
     let index: Base.Index
     let kind: Kind
@@ -78,12 +78,13 @@ extension Intersperse: Collection where Base: Collection {
 
   public func index(after i: Index) -> Index {
     switch i.kind {
-    case .element where base.index(after: i.index) == base.endIndex:
-      return endIndex
     case .element:
-      return Index(index: i.index, kind: .separator)
-    case .separator:
-      return Index(index: base.index(after: i.index), kind: .element)
+      let next = base.index(after: i.index)
+      return next == base.endIndex
+        ? endIndex
+        : Index(index: i.index, kind: .separator(next: next))
+    case .separator(let next):
+      return Index(index: next, kind: .element)
     }
   }
 
@@ -103,7 +104,7 @@ extension Intersperse: BidirectionalCollection
     case .element where i.index == base.endIndex:
       return Index(index: base.index(before: i.index), kind: .element)
     case .element:
-      return Index(index: base.index(before: i.index), kind: .separator)
+      return Index(index: base.index(before: i.index), kind: .separator(next: i.index))
     case .separator:
       return Index(index: i.index, kind: .element)
     }

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -109,15 +109,25 @@ extension Intersperse: Collection where Base: Collection {
 
   public func distance(from start: Index, to end: Index) -> Int {
     switch (start.representation, end.representation) {
-    case let (.element(lhs), .separator(next: rhs)),
-         let (.element(lhs), .element(rhs)) where rhs == base.endIndex:
-      return (2 * base.distance(from: lhs, to: rhs)) - 1
-    case let (.element(lhs), .element(rhs)),
-         let (.separator(lhs), .separator(rhs)),
-         let (.separator(next: lhs), .element(rhs)) where rhs == base.endIndex:
-      return 2 * base.distance(from: lhs, to: rhs)
-    case let (.separator(next: lhs), .element(rhs)):
-      return (2 * base.distance(from: lhs, to: rhs)) + 1
+    // Handling endIndex
+    case (.element(base.endIndex), .element(base.endIndex)):
+      return 0
+    case let (.element(element), .element(base.endIndex)):
+      return 2 * base.distance(from: element, to: base.endIndex) - 1
+    case let (.element(base.endIndex), .element(element)):
+      return 2 * base.distance(from: base.endIndex, to: element) + 1
+    case let (.separator(next: separator), .element(base.endIndex)):
+      return 2 * base.distance(from: separator, to: base.endIndex)
+    case let (.element(base.endIndex), .separator(next: separator)):
+      return 2 * base.distance(from: base.endIndex, to: separator)
+    // Non-endIndex cases
+    case let (.element(element), .separator(next: separator)):
+      return 2 * base.distance(from: element, to: separator) - 1
+    case let (.separator(next: separator), .element(element)):
+      return 2 * base.distance(from: separator, to: element) + 1
+    case let (.element(start), .element(end)),
+         let (.separator(start), .separator(end)):
+      return 2 * base.distance(from: start, to: end)
     }
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -14,7 +14,9 @@ import Algorithms
 
 final class IntersperseTests: XCTestCase {
   func testString() {
-    XCTAssertEqualSequences("ABCDE".interspersed(with: "-"), "A-B-C-D-E")
+    let interspersed = "ABCDE".interspersed(with: "-")
+    XCTAssertEqualSequences(interspersed, "A-B-C-D-E")
+    XCTAssertOrderedIndices(interspersed)
   }
 
   func testStringEmpty() {
@@ -22,7 +24,9 @@ final class IntersperseTests: XCTestCase {
   }
 
   func testArray() {
-    XCTAssertEqualSequences([1,2,3,4].interspersed(with: 0), [1,0,2,0,3,0,4])
+    let interspersed = [1,2,3,4].interspersed(with: 0)
+    XCTAssertEqualSequences(interspersed, [1,0,2,0,3,0,4])
+    XCTAssertOrderedIndices(interspersed)
   }
 
   func testArrayEmpty() {

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class IntersperseTests: XCTestCase {
+  func testString() {
+    XCTAssertEqualSequences("ABCDE".interspersed(with: "-"), "A-B-C-D-E")
+  }
+
+  func testStringEmpty() {
+    XCTAssertEqualSequences("".interspersed(with: "-"), "")
+  }
+
+  func testArray() {
+    XCTAssertEqualSequences([1,2,3,4].interspersed(with: 0), [1,0,2,0,3,0,4])
+  }
+
+  func testArrayEmpty() {
+    XCTAssertEqualSequences([].interspersed(with: 0), [])
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -13,6 +13,16 @@ import XCTest
 import Algorithms
 
 final class IntersperseTests: XCTestCase {
+  func testSequence() {
+    let interspersed = (1...).prefix(5).interspersed(with: 0)
+    XCTAssertEqualSequences(interspersed, [1,0,2,0,3,0,4,0,5])
+  }
+
+  func testSequenceEmpty() {
+    let interspersed = (1...).prefix(0).interspersed(with: 0)
+    XCTAssertEqualSequences(interspersed, [])
+  }
+
   func testString() {
     let interspersed = "ABCDE".interspersed(with: "-")
     XCTAssertEqualSequences(interspersed, "A-B-C-D-E")

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -16,23 +16,25 @@ final class IntersperseTests: XCTestCase {
   func testString() {
     let interspersed = "ABCDE".interspersed(with: "-")
     XCTAssertEqualSequences(interspersed, "A-B-C-D-E")
-    XCTAssertOrderedIndices(interspersed)
-    XCTAssertIndexDistances(interspersed)
+    validateIndexTraversals(interspersed)
   }
 
   func testStringEmpty() {
-    XCTAssertEqualSequences("".interspersed(with: "-"), "")
+    let interspersed = "".interspersed(with: "-")
+    XCTAssertEqualSequences(interspersed, "")
+    validateIndexTraversals(interspersed)
   }
 
   func testArray() {
     let interspersed = [1,2,3,4].interspersed(with: 0)
     XCTAssertEqualSequences(interspersed, [1,0,2,0,3,0,4])
-    XCTAssertOrderedIndices(interspersed)
-    XCTAssertIndexDistances(interspersed)
+    validateIndexTraversals(interspersed)
   }
 
   func testArrayEmpty() {
-    XCTAssertEqualSequences([].interspersed(with: 0), [])
+    let interspersed = [].interspersed(with: 0)
+    XCTAssertEqualSequences(interspersed, [])
+    validateIndexTraversals(interspersed)
   }
 
   func testCollection() {
@@ -43,5 +45,6 @@ final class IntersperseTests: XCTestCase {
   func testBidirectionalCollection() {
     let reversed = "ABCDE".interspersed(with: "-").reversed()
     XCTAssertEqualSequences(reversed, "E-D-C-B-A")
+    validateIndexTraversals(reversed)
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -17,6 +17,7 @@ final class IntersperseTests: XCTestCase {
     let interspersed = "ABCDE".interspersed(with: "-")
     XCTAssertEqualSequences(interspersed, "A-B-C-D-E")
     XCTAssertOrderedIndices(interspersed)
+    XCTAssertIndexDistances(interspersed)
   }
 
   func testStringEmpty() {
@@ -27,6 +28,7 @@ final class IntersperseTests: XCTestCase {
     let interspersed = [1,2,3,4].interspersed(with: 0)
     XCTAssertEqualSequences(interspersed, [1,0,2,0,3,0,4])
     XCTAssertOrderedIndices(interspersed)
+    XCTAssertIndexDistances(interspersed)
   }
 
   func testArrayEmpty() {

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -33,4 +33,9 @@ final class IntersperseTests: XCTestCase {
     let interspersed = ["A","B","C","D"].interspersed(with: "-")
     XCTAssertEqual(interspersed.count, 7)
   }
+
+  func testBidirectionalCollection() {
+    let reversed = "ABCDE".interspersed(with: "-").reversed()
+    XCTAssertEqualSequences(reversed, "E-D-C-B-A")
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -28,4 +28,9 @@ final class IntersperseTests: XCTestCase {
   func testArrayEmpty() {
     XCTAssertEqualSequences([].interspersed(with: 0), [])
   }
+
+  func testCollection() {
+    let interspersed = ["A","B","C","D"].interspersed(with: "-")
+    XCTAssertEqual(interspersed.count, 7)
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -256,32 +256,3 @@ func validateIndexTraversals<C>(
     }
   }
 }
-
-func XCTAssertOrderedIndices<C: Collection>(
-  _ expression: @autoclosure () throws -> C,
-  _ message: @autoclosure () -> String = "",
-  file: StaticString = #file, line: UInt = #line
-) rethrows {
-  let collection = try expression()
-  for indices in collection.indices.combinations(ofCount: 2) {
-    XCTAssertLessThan(indices[0], indices[1], message(), file: file, line: line)
-  }
-}
-
-func XCTAssertIndexDistances<C: Collection>(
-  _ expression: @autoclosure () throws -> C,
-  _ message: @autoclosure () -> String = "",
-  file: StaticString = #file, line: UInt = #line
-) rethrows {
-  let collection = try expression()
-  // Include the endIndex as it's a valid parameter to distance(from:to:).
-  let indices = Array(collection.indices) + [collection.endIndex]
-  for pairs in indices.combinations(ofCount: 2) {
-    let start = pairs[0]
-    let end = pairs[1]
-    let startPosition = indices.firstIndex(of: pairs[0])!
-    let endPosition = indices.firstIndex(of: pairs[1])!
-    let distance = collection.distance(from: start, to: end)
-    XCTAssertEqual(distance, endPosition - startPosition, message(), file: file, line: line)
-  }
-}

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -256,3 +256,14 @@ func validateIndexTraversals<C>(
     }
   }
 }
+
+func XCTAssertOrderedIndices<C: Collection>(
+  _ expression: @autoclosure () throws -> C,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) rethrows {
+  let collection = try expression()
+  for indices in collection.indices.combinations(ofCount: 2) {
+    XCTAssertLessThan(indices[0], indices[1], message(), file: file, line: line)
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -274,7 +274,8 @@ func XCTAssertIndexDistances<C: Collection>(
   file: StaticString = #file, line: UInt = #line
 ) rethrows {
   let collection = try expression()
-  let indices = Array(collection.indices)
+  // Include the endIndex as it's a valid parameter to distance(from:to:).
+  let indices = Array(collection.indices) + [collection.endIndex]
   for pairs in indices.combinations(ofCount: 2) {
     let start = pairs[0]
     let end = pairs[1]
@@ -282,9 +283,5 @@ func XCTAssertIndexDistances<C: Collection>(
     let endPosition = indices.firstIndex(of: pairs[1])!
     let distance = collection.distance(from: start, to: end)
     XCTAssertEqual(distance, endPosition - startPosition, message(), file: file, line: line)
-  }
-  for pairs in zip(indices, 0...) {
-    let distance = collection.distance(from: pairs.0, to: collection.endIndex)
-    XCTAssertEqual(distance, collection.count - pairs.1, message(), file: file, line: line)
   }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -267,3 +267,24 @@ func XCTAssertOrderedIndices<C: Collection>(
     XCTAssertLessThan(indices[0], indices[1], message(), file: file, line: line)
   }
 }
+
+func XCTAssertIndexDistances<C: Collection>(
+  _ expression: @autoclosure () throws -> C,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) rethrows {
+  let collection = try expression()
+  let indices = Array(collection.indices)
+  for pairs in indices.combinations(ofCount: 2) {
+    let start = pairs[0]
+    let end = pairs[1]
+    let startPosition = indices.firstIndex(of: pairs[0])!
+    let endPosition = indices.firstIndex(of: pairs[1])!
+    let distance = collection.distance(from: start, to: end)
+    XCTAssertEqual(distance, endPosition - startPosition, message(), file: file, line: line)
+  }
+  for pairs in zip(indices, 0...) {
+    let distance = collection.distance(from: pairs.0, to: collection.endIndex)
+    XCTAssertEqual(distance, collection.count - pairs.1, message(), file: file, line: line)
+  }
+}


### PR DESCRIPTION
### Description

This addition allows the caller to insert values between each element of a sequence. In this way you could have a string and insert a hyphen between each character or you could have an array of SwiftUI views and insert a separator view between each.

### Detailed Design

To achieve this, a new sequence type called Intersperse is added to the library. It also conforms to Collection and BidirectionalCollection when the base sequence conforms to those respective protocols.

For ease of use, a new method is added to sequence to allow the interspersing of the separator element:

```swift
extension Sequence {
    func interspersed(with separator: Element) -> Intersperse<Self>
}
```

It is crucial that the separator is only inserted between elements, so before returning the separator element, a lookup is performed on the base sequence to make sure the next element exists.

### Documentation Plan

As the `interspersed(with:)` method is the main entry point, this is documented with two examples of use which are taken from the included unit tests. The `Intersperse` sequence type itself is lightly documented, which I believe follows the trend of the current APIs in the library.

### Test Plan

Arrays of numbers and a String are used, calling `interspersed(with:)` on each,  a value between the elements of each. I have also tested that the empty sequence case yields an empty sequence.

### Source Impact

This is a purely additive change.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
