### PR TITLE
General index consistency tests

### DIFF
--- a/Tests/SwiftAlgorithmsTests/ChainTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChainTests.swift
@@ -13,14 +13,6 @@ import XCTest
 @testable import Algorithms
 
 final class ChainTests: XCTestCase {
-  // intentionally does not depend on `Chain.index(_:offsetBy:)` in order to
-  // avoid making assumptions about the code being tested
-  func index<A, B>(atOffset offset: Int, in chain: Chain2<A, B>) -> Chain2<A, B>.Index {
-    offset < chain.base1.count
-      ? .init(first: chain.base1.index(chain.base1.startIndex, offsetBy: offset))
-      : .init(second: chain.base2.index(chain.base2.startIndex, offsetBy: offset - chain.base1.count))
-  }
-  
   func testChainSequences() {
     let run = chain((1...).prefix(10), 20...)
     XCTAssertEqualSequences(run.prefix(20), Array(1...10) + (20..<30))
@@ -43,62 +35,17 @@ final class ChainTests: XCTestCase {
     XCTAssertEqualSequences(chain(s1.reversed(), s2), "JIHGFEDCBAklmnopqrstuv")
   }
   
-  func testChainIndexOffsetBy() {
-    let s1 = "abcde"
-    let s2 = "VWXYZ"
-    let c = chain(s1, s2)
-    
-    for (startOffset, endOffset) in product(0...c.count, 0...c.count) {
-      let start = index(atOffset: startOffset, in: c)
-      let end = index(atOffset: endOffset, in: c)
-      let distance = endOffset - startOffset
-      XCTAssertEqual(c.index(start, offsetBy: distance), end)
-    }
-  }
-  
-  func testChainIndexOffsetByLimitedBy() {
-    let s1 = "abcd"
-    let s2 = "XYZ"
-    let c = chain(s1, s2)
-    
-    for (startOffset, limitOffset) in product(0...c.count, 0...c.count) {
-      let start = index(atOffset: startOffset, in: c)
-      let limit = index(atOffset: limitOffset, in: c)
-      
-      // verifies that the target index corresponding to each offset in `range`
-      // can or cannot be reached from `start` using
-      // `c.index(start, offsetBy: _, limitedBy: limit)`, depending on the
-      // value of `beyondLimit`
-      func checkTargetRange(_ range: ClosedRange<Int>, beyondLimit: Bool) {
-        for targetOffset in range {
-          let distance = targetOffset - startOffset
-          
-          XCTAssertEqual(
-            c.index(start, offsetBy: distance, limitedBy: limit),
-            beyondLimit ? nil : index(atOffset: targetOffset, in: c))
-        }
-      }
-      
-      // forward
-      if limit >= start {
-        // the limit has an effect
-        checkTargetRange(startOffset...limitOffset, beyondLimit: false)
-        checkTargetRange((limitOffset + 1)...(c.count + 1), beyondLimit: true)
-      } else {
-        // the limit has no effect
-        checkTargetRange(startOffset...c.count, beyondLimit: false)
-      }
-      
-      // backward
-      if limit <= start {
-        // the limit has an effect
-        checkTargetRange(limitOffset...startOffset, beyondLimit: false)
-        checkTargetRange(-1...(limitOffset - 1), beyondLimit: true)
-      } else {
-        // the limit has no effect
-        checkTargetRange(0...startOffset, beyondLimit: false)
-      }
-    }
+  func testChainIndexTraversals() {
+    validateIndexTraversals(
+      chain("abcd", "XYZ"),
+      chain("abcd", ""),
+      chain("", "XYZ"),
+      chain("", ""),
+      indices: { chain in
+        chain.base1.indices.map { .init(first: $0) }
+          + chain.base2.indices.map { .init(second: $0) }
+          + [.init(second: chain.base2.endIndex)]
+      })
   }
   
   func testChainIndexOffsetAcrossBoundary() {
@@ -119,21 +66,6 @@ final class ChainTests: XCTestCase {
       let i = c.index(c.startIndex, offsetBy: 3)
       let j = c.index(i, offsetBy: -1, limitedBy: i)
       XCTAssertNil(j)
-    }
-  }
-  
-  func testChainDistanceFromTo() {
-    let s1 = "abcde"
-    let s2 = "VWXYZ"
-    let c = chain(s1, s2)
-    
-    XCTAssertEqual(c.count, s1.count + s2.count)
-    
-    for (startOffset, endOffset) in product(0...c.count, 0...c.count) {
-      let start = index(atOffset: startOffset, in: c)
-      let end = index(atOffset: endOffset, in: c)
-      let distance = endOffset - startOffset
-      XCTAssertEqual(c.distance(from: start, to: end), distance)
     }
   }
 }

--- a/Tests/SwiftAlgorithmsTests/ProductTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ProductTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 final class ProductTests: XCTestCase {
   func testProduct() {
@@ -36,5 +36,20 @@ final class ProductTests: XCTestCase {
   func testProductDistanceFromTo() {
     let p = product([1, 2], "abc")
     XCTAssertEqual(p.distance(from: p.startIndex, to: p.endIndex), 6)
+  }
+  
+  func testProductIndexTraversals() {
+    validateIndexTraversals(
+      product([1, 2, 3, 4], "abc"),
+      product([1, 2, 3, 4], ""),
+      product([], "abc"),
+      product([], ""),
+      indices: { product in
+        product.base1.indices.flatMap { i1 in
+          product.base2.indices.map { i2 in
+            .init(i1: i1, i2: i2)
+          }
+        } + [.init(i1: product.base1.endIndex, i2: product.base2.startIndex)]
+      })
   }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -73,23 +73,26 @@ func XCTAssertLazy<S: LazySequenceProtocol>(_: S) {}
 /// `indices`, `count`, `isEmpty`, `index(before:)`, `index(after:)`,
 /// `index(_:offsetBy:)`, `index(_:offsetBy:limitedBy:)`, and
 /// `distance(from:to:)` by calling them with just about all possible input
-/// combinations. The return values are validated using the given `indices`
-/// function, which is the source of truth.
+/// combinations. When provided, the `indices` function is used to to test the
+/// collection methods against.
 ///
 /// - Parameters:
 ///   - collections: The collections to be validated.
 ///   - indices: A closure that returns the expected indices of the given
-///     collection, including its `endIndex`, in ascending order.
+///     collection, including its `endIndex`, in ascending order. Only use this
+///     parameter if you are able to compute the indices of the collection
+///     independently of the `Collection` conformance, e.g. by using the
+///     contents of the collection directly.
 ///
 /// - Complexity: O(*n*^3) for each collection, where *n* is the length of the
 ///   collection.
 func validateIndexTraversals<C>(
   _ collections: C...,
-  indices: (C) -> [C.Index],
+  indices: ((C) -> [C.Index])? = nil,
   file: StaticString = #file, line: UInt = #line
 ) where C: BidirectionalCollection {
   for c in collections {
-    let indices = indices(c)
+    let indices = indices?(c) ?? (c.indices + [c.endIndex])
     let count = indices.count - 1
     
     XCTAssertEqual(

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -92,8 +92,8 @@ func validateIndexTraversals<C>(
   file: StaticString = #file, line: UInt = #line
 ) where C: BidirectionalCollection {
   for c in collections {
-    let indices = indices?(c) ?? (c.indices + [c.endIndex])
-    let count = indices.count - 1
+    let indicesIncludingEnd = indices?(c) ?? (c.indices + [c.endIndex])
+    let count = indicesIncludingEnd.count - 1
     
     XCTAssertEqual(
       c.count, count,
@@ -104,11 +104,11 @@ func validateIndexTraversals<C>(
       "Emptiness mismatch",
       file: file, line: line)
     XCTAssertEqual(
-      c.startIndex, indices.first,
+      c.startIndex, indicesIncludingEnd.first,
       "`startIndex` does not equal the first index",
       file: file, line: line)
     XCTAssertEqual(
-      c.endIndex, indices.last,
+      c.endIndex, indicesIncludingEnd.last,
       "`endIndex` does not equal the last index",
       file: file, line: line)
     
@@ -116,7 +116,7 @@ func validateIndexTraversals<C>(
     do {
       var index = c.startIndex
       
-      for (offset, expected) in indices.enumerated().dropFirst() {
+      for (offset, expected) in indicesIncludingEnd.enumerated().dropFirst() {
         c.formIndex(after: &index)
         XCTAssertEqual(
           index, expected,
@@ -132,7 +132,7 @@ func validateIndexTraversals<C>(
     do {
       var index = c.endIndex
 
-      for (offset, expected) in indices.enumerated().dropLast().reversed() {
+      for (offset, expected) in indicesIncludingEnd.enumerated().dropLast().reversed() {
         c.formIndex(before: &index)
         XCTAssertEqual(
           index, expected,
@@ -147,13 +147,13 @@ func validateIndexTraversals<C>(
     // `indices`
     for (offset, index) in c.indices.enumerated() {
       XCTAssertEqual(
-        index, indices[offset],
+        index, indicesIncludingEnd[offset],
         "Index mismatch at offset \(offset) in `indices`",
         file: file, line: line)
     }
     
     // index comparison
-    for (offsetA, a) in indices.enumerated() {
+    for (offsetA, a) in indicesIncludingEnd.enumerated() {
       XCTAssertEqual(
         a, a,
         "Index at offset \(offsetA) does not equal itself",
@@ -163,7 +163,7 @@ func validateIndexTraversals<C>(
         "Index at offset \(offsetA) is less than itself",
         file: file, line: line)
       
-      for (offsetB, b) in indices[..<offsetA].enumerated() {
+      for (offsetB, b) in indicesIncludingEnd[..<offsetA].enumerated() {
         XCTAssertNotEqual(
           a, b,
           "Index at offset \(offsetA) equals index at offset \(offsetB)",
@@ -178,8 +178,8 @@ func validateIndexTraversals<C>(
     }
     
     // `index(_:offsetBy:)` and `distance(from:to:)`
-    for (startOffset, start) in indices.enumerated() {
-      for (endOffset, end) in indices.enumerated() {
+    for (startOffset, start) in indicesIncludingEnd.enumerated() {
+      for (endOffset, end) in indicesIncludingEnd.enumerated() {
         let distance = endOffset - startOffset
         
         XCTAssertEqual(
@@ -200,8 +200,8 @@ func validateIndexTraversals<C>(
     }
     
     // `index(_:offsetBy:limitedBy:)`
-    for (startOffset, start) in indices.enumerated() {
-      for (limitOffset, limit) in indices.enumerated() {
+    for (startOffset, start) in indicesIncludingEnd.enumerated() {
+      for (limitOffset, limit) in indicesIncludingEnd.enumerated() {
         // verifies that the target index corresponding to each offset in
         // `range` can or cannot be reached from `start` using
         // `chain.index(start, offsetBy: _, limitedBy: limit)`, depending on the
@@ -221,7 +221,7 @@ func validateIndexTraversals<C>(
                 file: file, line: line)
             } else {
               XCTAssertEqual(
-                end, indices[targetOffset],
+                end, indicesIncludingEnd[targetOffset],
                 """
                 Index at offset \(startOffset) offset by \(distance) limited \
                 by index at offset \(limitOffset) does not equal index at \

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -145,6 +145,7 @@ func validateIndexTraversals<C>(
     }
     
     // `indices`
+    XCTAssertEqual(c.indices.count, count)
     for (offset, index) in c.indices.enumerated() {
       XCTAssertEqual(
         index, indicesIncludingEnd[offset],


### PR DESCRIPTION
This is a stab at making the index tests from `ChainTests` available to other collections as well (for now just `chain` and `product`). `validateIndexTraversals` validates a collection by taking an array of its indices as the source of truth, and verifying that all index operations (with just about any combination of arguments possible) are consistent with these indices.

`validateIndexTraversals` doesn't just use `c.indices + [c.endIndex]` as the indices to test against because that might not catch a bug in the implementation of `indices` itself (or e.g. `index(after:)` or `Index.==`). Having to provide an array of indices that are known to be correct prevents these kinds of bugs from slipping through. As an example, the index array of a `Chain2` instance is computed like this:

```swift
chain.base1.indices.map { .init(first: $0) }
  + chain.base2.indices.map { .init(second: $0) }
  + [.init(second: chain.base2.endIndex)]
```

The previous bugs in `Chain2` and `Product2` would all have been caught by this, so this would give me a bit more confidence before attempting `Product2.index(_:offsetBy:)` 🙂 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
