### PR TITLE
Add random-access methods to SlidingWindows

### DIFF
--- a/Sources/Algorithms/SlidingWindows.swift
+++ b/Sources/Algorithms/SlidingWindows.swift
@@ -84,9 +84,198 @@ extension SlidingWindows: Collection {
     )
   }
   
-  // TODO: Implement distance(from:to:), index(_:offsetBy:) and
-  // index(_:offsetBy:limitedBy:)
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    guard distance != 0 else { return i }
+    
+    return distance > 0
+      ? offsetForward(i, by: distance)
+      : offsetBackward(i, by: -distance)
+  }
+  
+  public func index(
+    _ i: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    guard distance != 0 else { return i }
+    guard limit != i else { return nil }
+    
+    if distance > 0 {
+      return limit > i
+        ? offsetForward(i, by: distance, limitedBy: limit)
+        : offsetForward(i, by: distance)
+    } else {
+      return limit < i
+        ? offsetBackward(i, by: -distance, limitedBy: limit)
+        : offsetBackward(i, by: -distance)
+    }
+  }
+  
+  private func offsetForward(_ i: Index, by distance: Int) -> Index {
+    offsetForward(i, by: distance, limitedBy: endIndex)!
+  }
+  
+  private func offsetBackward(_ i: Index, by distance: Int) -> Index {
+    offsetBackward(i, by: distance, limitedBy: startIndex)!
+  }
+  
+  private func offsetForward(
+    _ i: Index, by distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    assert(distance > 0)
+    assert(limit > i)
+    
+    // `endIndex` and the index before it both have `base.endIndex` as their
+    // upper bound, so we first advance to the base index _before_ the upper
+    // bound of the output, in order to avoid advancing past the end of `base`
+    // when advancing to `endIndex`.
+    //
+    // Advancing by 4:
+    //
+    //  input: [x|x x x x x|x x x x]        [x x|x x x x x|x x x]
+    //                     |> > >|>|   or                 |> > >|
+    // output: [x x x x x|x x x x x]        [x x x x x x x x x x]  (`endIndex`)
+    
+    if distance >= size {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the lower
+      // bound of the output is greater than or equal to the upper bound of the
+      // input.
+      
+      //  input: [x|x x x x|x x x x x x x]
+      //                   |> >|> > >|>|
+      // output: [x x x x x x x|x x x x|x]
+      
+      guard limit.lowerBound >= i.upperBound,
+            let lowerBound = base.index(
+              i.upperBound,
+              offsetBy: distance - size,
+              limitedBy: limit.lowerBound),
+            let indexBeforeUpperBound = base.index(
+              lowerBound,
+              offsetBy: size - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+      
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(after: indexBeforeUpperBound))
+    } else {
+      //  input: [x|x x x x x x|x x x x x]
+      //           |> > > >|   |> > >|>|
+      // output: [x x x x x|x x x x x x|x]
+      
+      guard let indexBeforeUpperBound = base.index(
+              i.upperBound,
+              offsetBy: distance - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      // If `indexBeforeUpperBound` equals the limit, the upper bound itself
+      // exceeds it.
+      guard indexBeforeUpperBound != limit.upperBound || limit == endIndex
+        else { return nil }
+      
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+      
+      return Index(
+        lowerBound: base.index(i.lowerBound, offsetBy: distance),
+        upperBound: base.index(after: indexBeforeUpperBound))
+    }
+  }
+  
+  private func offsetBackward(
+      _ i: Index, by distance: Int, limitedBy limit: Index
+    ) -> Index? {
+    assert(distance > 0)
+    assert(limit < i)
+    
+    if i == endIndex {
+      // Advance `base.endIndex` by `distance - 1`, because the index before
+      // `endIndex` also has `base.endIndex` as its upper bound.
+      //
+      // Advancing by 4:
+      //
+      //  input: [x x x x x x x x x x]  (`endIndex`)
+      //             |< < < < <|< < <|
+      // output: [x x|x x x x x|x x x]
+      
+      guard let upperBound = base.index(
+              base.endIndex,
+              offsetBy: -(distance - 1),
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -size),
+        upperBound: upperBound)
+    } else if distance >= size {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the upper
+      // bound of the output is less than or equal to the lower bound of the
+      // input.
+      //
+      //  input: [x x x x x x x|x x x x|x]
+      //           |< < < <|< <|
+      // output: [x|x x x x|x x x x x x x]
+      
+      guard limit.upperBound <= i.lowerBound,
+            let upperBound = base.index(
+              i.lowerBound,
+              offsetBy: -(distance - size),
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -size),
+        upperBound: upperBound)
+    } else {
+      //  input: [x x x x x|x x x x x x|x]
+      //           |< < < <|   |< < < <|
+      // output: [x|x x x x x x|x x x x x]
+      
+      guard let lowerBound = base.index(
+              i.lowerBound,
+              offsetBy: -distance,
+              limitedBy: limit.lowerBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(i.lowerBound, offsetBy: -distance))
+    }
+  }
+  
+  public func distance(from start: Index, to end: Index) -> Int {
+    guard start <= end else { return -distance(from: end, to: start) }
+    guard start != end else { return 0 }
+    guard end < endIndex else {
+      // We add 1 here because the index before `endIndex` also has
+      // `base.endIndex` as its upper bound.
+      return base[start.upperBound...].count + 1
+    }
 
+    if start.upperBound <= end.lowerBound {
+      // The distance between `start.lowerBound` and `start.upperBound` is
+      // already known.
+      //
+      // start: [x|x x x x|x x x x x x x]
+      //          |- - - -|> >|
+      //   end: [x x x x x x x|x x x x|x]
+      
+      return size + base[start.upperBound..<end.lowerBound].count
+    } else {
+      // start: [x|x x x x x x|x x x x x]
+      //          |> > > >|
+      //   end: [x x x x x|x x x x x x|x]
+      
+      return base[start.lowerBound..<end.lowerBound].count
+    }
+  }
 }
 
 extension SlidingWindows: BidirectionalCollection where Base: BidirectionalCollection {

--- a/Sources/Algorithms/SlidingWindows.swift
+++ b/Sources/Algorithms/SlidingWindows.swift
@@ -112,11 +112,15 @@ extension SlidingWindows: Collection {
   }
   
   private func offsetForward(_ i: Index, by distance: Int) -> Index {
-    offsetForward(i, by: distance, limitedBy: endIndex)!
+    guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
   }
   
   private func offsetBackward(_ i: Index, by distance: Int) -> Index {
-    offsetBackward(i, by: distance, limitedBy: startIndex)!
+    guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
   }
   
   private func offsetForward(

--- a/Tests/SwiftAlgorithmsTests/SlidingWindowsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/SlidingWindowsTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 final class SlidingWindowsTests: XCTestCase {
   
@@ -88,4 +88,22 @@ final class SlidingWindowsTests: XCTestCase {
     XCTAssertEqualSequences(a[i], [1, 2])
   }
   
+  func testWindowsIndexTraversals() {
+    validateIndexTraversals(
+      "".slidingWindows(ofCount: 1),
+      "a".slidingWindows(ofCount: 1),
+      "ab".slidingWindows(ofCount: 1),
+      "abc".slidingWindows(ofCount: 1),
+      "".slidingWindows(ofCount: 3),
+      "a".slidingWindows(ofCount: 3),
+      "abc".slidingWindows(ofCount: 3),
+      "abcdefgh".slidingWindows(ofCount: 3),
+      indices: { windows in
+        let endIndex = windows.base.endIndex
+        let indices = windows.base.indices + [endIndex]
+        return zip(indices, indices.dropFirst(windows.size))
+          .map { .init(lowerBound: $0, upperBound: $1) }
+          + [.init(lowerBound: endIndex, upperBound: endIndex)]
+      })
+  }
 }


### PR DESCRIPTION
`index(_:offsetBy:)`, `index(_:offsetBy:limitedBy:)`, and `distance(from:to:)` for `SlidingWindows`.

The `base.endIndex..<base.endIndex` representation of `endIndex` made this a bit tricky, because neither of the bounds is a logical successor of the index before it. The `offsetForward`/`offsetBackward` dance alleviates this somewhat by ensuring that the limit is always on the correct side of `i` and never equal to it, removing some of the edge cases.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
