### PR TITLE
Unify chunked(by:) and chunked(on:)

### DIFF
--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -95,6 +95,7 @@ extension LazyChunked: LazyCollectionProtocol {
   
   @inlinable
   public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Can't advance past endIndex")
     let upperBound = i.upperBound ?? endOfChunk(startingAt: i.lowerBound)
     guard upperBound != base.endIndex else { return endIndex }
     let end = endOfChunk(startingAt: upperBound)
@@ -140,6 +141,7 @@ extension LazyChunked: BidirectionalCollection
 
   @inlinable
   public func index(before i: Index) -> Index {
+    precondition(i != startIndex, "Can't advance before startIndex")
     let start = startOfChunk(endingAt: i.lowerBound)
     return Index(lowerBound: start, upperBound: i.lowerBound)
   }

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -9,17 +9,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct LazyChunked<Base: Collection> {
+public struct LazyChunked<Base: Collection, Subject> {
   /// The collection that this instance provides a view onto.
   public let base: Base
   
   /// The projection function.
   @usableFromInline
-  internal var belongInSameGroup: (Base.Element, Base.Element) -> Bool
+  internal let projection: (Base.Element) -> Subject
+  
+  /// The predicate.
+  @usableFromInline
+  internal let belongInSameGroup: (Subject, Subject) -> Bool
   
   @usableFromInline
-  internal init(base: Base, belongInSameGroup: @escaping (Base.Element, Base.Element) -> Bool) {
+  internal init(
+    base: Base,
+    projection: @escaping (Base.Element) -> Subject,
+    belongInSameGroup: @escaping (Subject, Subject) -> Bool
+  ) {
     self.base = base
+    self.projection = projection
     self.belongInSameGroup = belongInSameGroup
   }
 }
@@ -69,8 +78,10 @@ extension LazyChunked: LazyCollectionProtocol {
   @usableFromInline
   internal func endOfChunk(from i: Base.Index) -> Base.Index {
     guard i != base.endIndex else { return base.endIndex }
+    let subject = projection(base[i])
     return base[base.index(after: i)...]
-      .firstIndex(where: { !belongInSameGroup($0, base[i]) }) ?? base.endIndex
+      .firstIndex(where: { !belongInSameGroup(subject, projection($0)) })
+      ?? base.endIndex
   }
   
   @inlinable
@@ -107,13 +118,15 @@ extension LazyChunked: BidirectionalCollection
   /// the chunk ending at the given index.
   @usableFromInline
   internal func startOfChunk(endingAt end: Base.Index) -> Base.Index {
+    let indexBeforeEnd = base.index(before: end)
+    
     // Get the projected value of the last element in the range ending at `end`.
-    let lastOfPreviousChunk = base[base.index(before: end)]
+    let subject = projection(base[indexBeforeEnd])
     
     // Search backward from `end` for the first element whose projection isn't
-    // equal to `lastOfPreviousChunk`.
-    if let firstMismatch = base[..<end]
-      .lastIndex(where: { !belongInSameGroup($0, lastOfPreviousChunk) })
+    // equal to `subject`.
+    if let firstMismatch = base[..<indexBeforeEnd]
+      .lastIndex(where: { !belongInSameGroup(projection($0), subject) })
     {
       // If we found one, that's the last element of the _next_ previous chunk,
       // and therefore one position _before_ the start of this chunk.
@@ -146,8 +159,11 @@ extension LazyCollectionProtocol {
   @inlinable
   public func chunked(
     by belongInSameGroup: @escaping (Element, Element) -> Bool
-  ) -> LazyChunked<Elements> {
-    LazyChunked(base: elements, belongInSameGroup: belongInSameGroup)
+  ) -> LazyChunked<Elements, Element> {
+    LazyChunked(
+      base: elements,
+      projection: { $0 },
+      belongInSameGroup: belongInSameGroup)
   }
   
   /// Returns a lazy collection of subsequences of this collection, chunked by
@@ -159,10 +175,11 @@ extension LazyCollectionProtocol {
   @inlinable
   public func chunked<Subject: Equatable>(
     on projection: @escaping (Element) -> Subject
-  ) -> LazyChunked<Elements> {
+  ) -> LazyChunked<Elements, Subject> {
     LazyChunked(
       base: elements,
-      belongInSameGroup: { projection($0) == projection($1) })
+      projection: projection,
+      belongInSameGroup: ==)
   }
 }
 


### PR DESCRIPTION
Unify `chunked(by:)` and `chunked(on:)` by:

- forwarding the eager versions to a new internal `chunked(on:by:)`, and
- having `LazyChunked` store both a projection function and a predicate.

The status quo of `chunked(on:)` calling `chunked(by: { f($0) == f($1) })` causes more calls to the projection function than necessary, specifically by repeatedly calling it with the first element of the chunk. Unifying `chunked(by:)` and `chunked(on:)` allows this projected value to be stored and reused.

This PR also slightly improves `endOfChunk(startingAt:)` by moving the `endIndex` check to `index(after:)` (at the only point where it can ever be hit). This change, together with changing the `endIndex` representation to have no upper bound, has the pleasant consequence that `chunked[chunked.endIndex]` and `chunked.index(after: chunked.endIndex)` now both trap rather than returning an empty slice and `endIndex`, respectively.

Open questions:
- `LazyChunked.Index` could store the projected value. This saves a single call to the projection function for each chunk, but for `chunked(by:)` it only increases the size of the index without any benefit. This does not seem like a clear win so I chose to keep `Index` lean for now.
- Should `chunked(on:by:)` be public as well? I've left the public API unchanged but I think exposing it might be the nice thing to do.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
