### PR TITLE
Add conformances to LazySequenceProtocol and LazyCollectionProtocol

### DIFF
--- a/Guides/Indexed.md
+++ b/Guides/Indexed.md
@@ -30,6 +30,6 @@ extension Collection {
 ```
 
 `Indexed` scales from a collection up to a random-access collection, depending on 
-its base type. `Indexed` also conforms to `LazySequenceProtocol` when the base type
-conforms.
+its base type. `Indexed` also conforms to `LazySequenceProtocol` and 
+`LazyCollectionProtocol` when the base type conforms.
 

--- a/Guides/Intersperse.md
+++ b/Guides/Intersperse.md
@@ -30,9 +30,9 @@ extension Sequence {
 ```
 
 The new `Intersperse` type represents the sequence when the separator is
-inserted between each element. Intersperse conforms to Collection and 
-BidirectionalCollection when the base sequence conforms to Collection and
-BidirectionalCollection respectively.
+inserted between each element. `Intersperse` conforms to `Collection`,
+`BidirectionalCollection`, `RandomAccessCollection`, and `LazySequenceProtocol`
+when the base sequence conforms to those respective protocols.
 
 ### Complexity
 

--- a/Guides/Intersperse.md
+++ b/Guides/Intersperse.md
@@ -31,8 +31,9 @@ extension Sequence {
 
 The new `Intersperse` type represents the sequence when the separator is
 inserted between each element. `Intersperse` conforms to `Collection`,
-`BidirectionalCollection`, `RandomAccessCollection`, and `LazySequenceProtocol`
-when the base sequence conforms to those respective protocols.
+`BidirectionalCollection`, `RandomAccessCollection`, `LazySequenceProtocol` and
+`LazyCollectionProtocol` when the base sequence conforms to those respective
+protocols.
 
 ### Complexity
 

--- a/Guides/SlidingWindows.md
+++ b/Guides/SlidingWindows.md
@@ -37,8 +37,8 @@ The first upper bound is computed eagerly because it determines if the collectio
 ```
 
 The resulting `SlidingWindows` type is a collection, with conditional conformance to the 
-`BidirectionalCollection`, and `RandomAccessCollection`  when the base collection
-conforms.
+`BidirectionalCollection`, `RandomAccessCollection`, and
+`LazyCollectionProtocol` when the base collection conforms.
 
 ### Complexity
 

--- a/Sources/Algorithms/Indexed.swift
+++ b/Sources/Algorithms/Indexed.swift
@@ -70,6 +70,7 @@ extension Indexed: BidirectionalCollection where Base: BidirectionalCollection {
 
 extension Indexed: RandomAccessCollection where Base: RandomAccessCollection {}
 extension Indexed: LazySequenceProtocol where Base: LazySequenceProtocol {}
+extension Indexed: LazyCollectionProtocol where Base: LazyCollectionProtocol {}
 extension Indexed: Equatable where Base: Equatable {}
 extension Indexed: Hashable where Base: Hashable {}
 

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -155,6 +155,9 @@ extension Intersperse: RandomAccessCollection
 extension Intersperse: LazySequenceProtocol
   where Base: LazySequenceProtocol {}
 
+extension Intersperse: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
 extension Sequence {
 
   /// Returns a sequence containing elements of this sequence with the given

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -152,6 +152,9 @@ extension Intersperse: BidirectionalCollection
 extension Intersperse: RandomAccessCollection
   where Base: RandomAccessCollection {}
 
+extension Intersperse: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
 extension Sequence {
 
   /// Returns a sequence containing elements of this sequence with the given

--- a/Sources/Algorithms/SlidingWindows.swift
+++ b/Sources/Algorithms/SlidingWindows.swift
@@ -299,6 +299,8 @@ extension SlidingWindows: BidirectionalCollection where Base: BidirectionalColle
   }
 }
 
+extension SlidingWindows: LazySequenceProtocol where Base: LazySequenceProtocol {}
+extension SlidingWindows: LazyCollectionProtocol where Base: LazyCollectionProtocol {}
 extension SlidingWindows: RandomAccessCollection where Base: RandomAccessCollection {}
 extension SlidingWindows: Equatable where Base: Equatable {}
 extension SlidingWindows: Hashable where Base: Hashable, Base.Index: Hashable {}

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -73,7 +73,7 @@ final class ChunkedTests: XCTestCase {
   }
   
   func testChunkedLazy() {
-    XCTAssertLazy(fruits.lazy.chunked(by: { $0.first == $1.first }))
-    XCTAssertLazy(fruits.lazy.chunked(on: { $0.first }))
+    XCTAssertLazySequence(fruits.lazy.chunked(by: { $0.first == $1.first }))
+    XCTAssertLazySequence(fruits.lazy.chunked(on: { $0.first }))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -40,6 +40,6 @@ final class CombinationsTests: XCTestCase {
   }
   
   func testCombinationsLazy() {
-    XCTAssertLazy("ABC".lazy.combinations(ofCount: 1))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CycleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CycleTests.swift
@@ -41,6 +41,6 @@ final class CycleTests: XCTestCase {
   }
   
   func testCycleLazy() {
-    XCTAssertLazy((1...4).lazy.cycled())
+    XCTAssertLazySequence((1...4).lazy.cycled())
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IndexedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IndexedTests.swift
@@ -29,6 +29,6 @@ final class IndexedTests: XCTestCase {
   }
   
   func testIndexedLazy() {
-    XCTAssertLazySequence("ABCD".lazy.indexed())
+    XCTAssertLazyCollection("ABCD".lazy.indexed())
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IndexedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IndexedTests.swift
@@ -29,6 +29,6 @@ final class IndexedTests: XCTestCase {
   }
   
   func testIndexedLazy() {
-    XCTAssertLazy("ABCD".lazy.indexed())
+    XCTAssertLazySequence("ABCD".lazy.indexed())
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -57,4 +57,9 @@ final class IntersperseTests: XCTestCase {
     XCTAssertEqualSequences(reversed, "E-D-C-B-A")
     validateIndexTraversals(reversed)
   }
+
+  func testIntersperseLazy() {
+    XCTAssertLazySequence((1...).prefix(0).lazy.interspersed(with: 0))
+    XCTAssertLazyCollection("ABCDE".lazy.interspersed(with: "-"))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
@@ -71,6 +71,6 @@ final class PermutationsTests: XCTestCase {
   }
   
   func testPermutationsLazy() {
-    XCTAssertLazy("ABCD".lazy.permutations(ofCount: 2))
+    XCTAssertLazySequence("ABCD".lazy.permutations(ofCount: 2))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/SlidingWindowsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/SlidingWindowsTests.swift
@@ -106,4 +106,8 @@ final class SlidingWindowsTests: XCTestCase {
           + [.init(lowerBound: endIndex, upperBound: endIndex)]
       })
   }
+
+  func testWindowsLazy() {
+    XCTAssertLazyCollection([0, 1, 2, 3].lazy.slidingWindows(ofCount: 2))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -65,7 +65,7 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
   try XCTAssert(expression1().elementsEqual(expression2(), by: areEquivalent), message(), file: file, line: line)
 }
 
-func XCTAssertLazy<S: LazySequenceProtocol>(_: S) {}
+func XCTAssertLazySequence<S: LazySequenceProtocol>(_: S) {}
 
 /// Tests that all index traversal methods behave as expected.
 ///

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -66,6 +66,7 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
 }
 
 func XCTAssertLazySequence<S: LazySequenceProtocol>(_: S) {}
+func XCTAssertLazyCollection<S: LazyCollectionProtocol>(_: S) {}
 
 /// Tests that all index traversal methods behave as expected.
 ///


### PR DESCRIPTION
This fixes an omission in `Intersperse` where it doesn't currently conform to `LazySequenceProtocol` when the base sequence also conforms to `LazySequenceProtocol`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
