### PR TITLE
Rename `trimming(where:)` to `trimming(while:)`

### DIFF
--- a/Guides/Trim.md
+++ b/Guides/Trim.md
@@ -6,13 +6,13 @@
 Returns a `SubSequence` formed by discarding all elements at the start and end of the collection
 which satisfy the given predicate.
 
-This example uses `trimming(where:)` to get a substring without the white space at the beginning and end of the string.
+This example uses `trimming(while:)` to get a substring without the white space at the beginning and end of the string.
 
 ```swift
 let myString = "   hello, world  "
-print(myString.trimming(where: \.isWhitespace)) // "hello, world"
+print(myString.trimming(while: \.isWhitespace)) // "hello, world"
 
-let results = [2, 10, 11, 15, 20, 21, 100].trimming(where: { $0.isMultiple(of: 2) })
+let results = [2, 10, 11, 15, 20, 21, 100].trimming(while: { $0.isMultiple(of: 2) })
 print(results) // [11, 15, 20, 21]
 ```
 
@@ -23,7 +23,7 @@ A new method is added to `BidirectionalCollection`:
 ```swift
 extension BidirectionalCollection {
 
-  public func trimming(where predicate: (Element) throws -> Bool) rethrows -> SubSequence
+  public func trimming(while predicate: (Element) throws -> Bool) rethrows -> SubSequence
 }
 ```
 
@@ -36,12 +36,12 @@ to add the `BidirectionalCollection` constraint will receive that inefficient im
 ```swift
 func myAlgorithm<Input>(input: Input) where Input: Collection {
 
-  let trimmedInput = input.trimming(where: { ... }) // Uses least-efficient implementation.
+  let trimmedInput = input.trimming(while: { ... }) // Uses least-efficient implementation.
 }
 
 func myAlgorithm2<Input>(input: Input) where Input: BidirectionalCollection {
 
-  let trimmedInput = input.trimming(where: { ... }) // Uses most-efficient implementation.
+  let trimmedInput = input.trimming(while: { ... }) // Uses most-efficient implementation.
 }
 ```
 
@@ -107,8 +107,8 @@ languages:
 ```swift
 // Does `result` contain the input, trimmed of certain elements?
 // Or does this code mutate `input` in-place and return the elements which were dropped?
-let result = input.dropFromBothEnds(where: { ... })
+let result = input.dropFromBothEnds(while: { ... })
 
 // No such ambiguity here.
-let result = input.trimming(where: { ... })
+let result = input.trimming(while: { ... })
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`chunked(by:)`, `chunked(on:)`, `chunks(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes or chunks of a given count.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
-- [`trimming(where:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end. 
+- [`trimming(while:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end.
 - [`slidingWindows(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/SlidingWindows.md): Breaks a collection into overlapping contiguous window subsequences where elements are slices from the original collection.
 - [`striding(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Stride.md): Returns every nth element of a collection.
 

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -13,11 +13,11 @@ extension BidirectionalCollection {
   /// Returns a `SubSequence` formed by discarding all elements at the start and
   /// end of the collection which satisfy the given predicate.
   ///
-  /// This example uses `trimming(where:)` to get a substring without the white
+  /// This example uses `trimming(while:)` to get a substring without the white
   /// space at the beginning and end of the string:
   ///
   ///     let myString = "  hello, world  "
-  ///     print(myString.trimming(where: \.isWhitespace)) // "hello, world"
+  ///     print(myString.trimming(while: \.isWhitespace)) // "hello, world"
   ///
   /// - Parameters:
   ///    - predicate: A closure which determines if the element should be
@@ -27,7 +27,7 @@ extension BidirectionalCollection {
   ///
   @inlinable
   public func trimming(
-    where predicate: (Element) throws -> Bool
+    while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     // Consume elements from the front.
     let sliceStart = try firstIndex { try predicate($0) == false } ?? endIndex


### PR DESCRIPTION
The `where:` argument label is more commonly used:

* `Sequence.contains(where:)`
* `Sequence.first(where:)`
* `Collection.firstIndex(where:)`
* `BidirectionalCollection.last(where:)`
* `BidirectionalCollection.lastIndex(where:)`
* `RangeReplaceableCollection.removeAll(where:)`

But the `while:` argument label is used for "consecutive elements that satisfy the given predicate":

* `Sequence.drop(while:)`
* `Sequence.prefix(while:)`

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary