### PR TITLE
All combinations

### DIFF
--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -36,6 +36,52 @@ for combo in numbers2.combinations(ofCount: 2) {
 // [10, 10]
 ```
 
+The `combinations(ofCounts:)` method returns a sequence of all the different
+combinations of the given sizes of a collection’s elements in increasing order of size.
+
+```swift
+let numbers = [10, 20, 30, 40]
+for combo in numbers(ofCounts: 2...3) {
+    print(combo)
+}
+// [10, 20]
+// [10, 30]
+// [10, 40]
+// [20, 30]
+// [20, 40]
+// [30, 40]
+// [10, 20, 30]
+// [10, 20, 40]
+// [10, 30, 40]
+// [20, 30, 40]
+```
+
+The `combinations()` method returns a sequence of *all* the different
+combinations of a collection’s elements in increasing order of size.
+
+```swift
+let numbers = [10, 20, 30, 40]
+for combo in numbers.combinations() {
+    print(combo)
+}
+// []
+// [10]
+// [20]
+// [30]
+// [40]
+// [10, 20]
+// [10, 30]
+// [10, 40]
+// [20, 30]
+// [20, 40]
+// [30, 40]
+// [10, 20, 30]
+// [10, 20, 40]
+// [10, 30, 40]
+// [20, 30, 40]
+// [10, 20, 30, 40]
+```
+
 ## Detailed Design
 
 The `combinations(ofCount:)` method is declared as a  `Collection` extension,

--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -36,13 +36,13 @@ for combo in numbers2.combinations(ofCount: 2) {
 // [10, 10]
 ```
 
-The `combinations(ofCounts:)` method returns a sequence of all the different
-combinations of the given sizes of a collection’s elements in increasing order
-of size.
+Given a range, the `combinations(ofCount:)` method returns a sequence of all
+the different combinations of the given sizes of a collection’s elements in
+increasing order of size.
 
 ```swift
 let numbers = [10, 20, 30, 40]
-for combo in numbers(ofCounts: 2...3) {
+for combo in numbers.combinations(ofCount: 2...3) {
     print(combo)
 }
 // [10, 20]

--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -56,32 +56,6 @@ for combo in numbers(ofCounts: 2...3) {
 // [20, 30, 40]
 ```
 
-The `combinations()` method returns a sequence of *all* the different
-combinations of a collection’s elements in increasing order of size.
-
-```swift
-let numbers = [10, 20, 30, 40]
-for combo in numbers.combinations() {
-    print(combo)
-}
-// []
-// [10]
-// [20]
-// [30]
-// [40]
-// [10, 20]
-// [10, 30]
-// [10, 40]
-// [20, 30]
-// [20, 40]
-// [30, 40]
-// [10, 20, 30]
-// [10, 20, 40]
-// [10, 30, 40]
-// [20, 30, 40]
-// [10, 20, 30, 40]
-```
-
 ## Detailed Design
 
 The `combinations(ofCount:)` method is declared as a  `Collection` extension,

--- a/Guides/Combinations.md
+++ b/Guides/Combinations.md
@@ -37,7 +37,8 @@ for combo in numbers2.combinations(ofCount: 2) {
 ```
 
 The `combinations(ofCounts:)` method returns a sequence of all the different
-combinations of the given sizes of a collection’s elements in increasing order of size.
+combinations of the given sizes of a collection’s elements in increasing order
+of size.
 
 ```swift
 let numbers = [10, 20, 30, 40]
@@ -76,9 +77,9 @@ array at every index advancement. `Combinations` does conform to
 
 ### Complexity
 
-Calling `combinations(ofCount:)` accesses the count of the collection, so it’s an
-O(1) operation for random-access collections, or an O(_n_) operation otherwise.
-Creating the iterator for a `Combinations` instance and each call to
+Calling `combinations(ofCount:)` accesses the count of the collection, so it’s
+an O(1) operation for random-access collections, or an O(_n_) operation
+otherwise. Creating the iterator for a `Combinations` instance and each call to
 `Combinations.Iterator.next()` is an O(_n_) operation.
 
 ### Naming

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Combinations / permutations
 
-- [`combinations(ofCount:)`, `combinations(ofCounts:)`, `combinations()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
+- [`combinations(ofCount:)`, `combinations(ofCounts:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
 - [`permutations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Permutations.md): Permutations of a particular size of the elements in a collection, or of the full collection.
 
 #### Mutating algorithms

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Combinations / permutations
 
-- [`combinations(ofCount:)`, `combinations(ofCounts:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
+- [`combinations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
 - [`permutations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Permutations.md): Permutations of a particular size of the elements in a collection, or of the full collection.
 
 #### Mutating algorithms

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Combinations / permutations
 
-- [`combinations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of a particular size of the elements in a collection.
+- [`combinations(ofCount:)`, `combinations(ofCounts:)`, `combinations()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
 - [`permutations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Permutations.md): Permutations of a particular size of the elements in a collection, or of the full collection.
 
 #### Mutating algorithms

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -239,8 +239,8 @@ extension Collection {
   ///     // [10, 20, 30, 40]
   ///
   /// If `kRange` is `0...0`, the resulting sequence has exactly one element, an
-  /// empty array. If `k.upperBound` is greater than the number of elements in
-  /// this sequence, the resulting sequence has no elements.
+  /// empty array. The given range is limited to `0...base.count`. If the
+  /// limited range is empty, the resulting sequence has no elements.
   ///
   /// - Parameter kRange: The range of numbers of elements to include in each
   /// combination.

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -15,7 +15,7 @@ public struct Combinations<Base: Collection> {
   public let base: Base
   
   @usableFromInline
-  internal var k: Int
+  internal let k: Int
   
   @usableFromInline
   internal init(_ base: Base, k: Int) {

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -14,6 +14,9 @@ public struct Combinations<Base: Collection> {
   /// The collection to iterate over for combinations.
   public let base: Base
   
+  @usableFromInline
+  internal let baseCount: Int
+  
   /// The range of accepted sizes of combinations.
   /// - Note: This may be `nil` if the attempted range entirely exceeds the
   /// upper bounds of the size of the `base` collection.
@@ -40,9 +43,11 @@ public struct Combinations<Base: Collection> {
   ) where R.Bound == Int {
     let range = kRange.relative(to: 0 ..< .max)
     self.base = base
-    let upperBound = base.count + 1
+    let baseCount = base.count
+    self.baseCount = baseCount
+    let upperBound = baseCount + 1
     self.kRange = range.lowerBound < upperBound
-      ? range.clamped(to: 0..<upperBound)
+      ? range.clamped(to: 0 ..< upperBound)
       : nil
   }
   
@@ -50,8 +55,8 @@ public struct Combinations<Base: Collection> {
   @inlinable
   public var count: Int {
     guard let k = self.kRange else { return 0 }
-    let n = base.count
-    if k == 0..<(n + 1) {
+    let n = baseCount
+    if k == 0 ..< (n + 1) {
       return 1 << n
     }
     
@@ -123,7 +128,7 @@ extension Combinations: Sequence {
       func advanceKRange() {
         if kRange.lowerBound < kRange.upperBound {
           let advancedLowerBound = kRange.lowerBound + 1
-          kRange = advancedLowerBound..<kRange.upperBound
+          kRange = advancedLowerBound ..< kRange.upperBound
           indexes.removeAll(keepingCapacity: true)
           indexes.append(contentsOf: base.indices.prefix(kRange.lowerBound))
         }

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -122,7 +122,7 @@ extension Combinations: Sequence {
     internal mutating func advance() {
       /// Advances `k` by increasing its `lowerBound` or finishes the iteration.
       func advanceK() {
-        let advancedLowerBound = k.lowerBound.advanced(by: 1)
+        let advancedLowerBound = k.lowerBound + 1
         if advancedLowerBound < k.upperBound {
           k = advancedLowerBound..<k.upperBound
           self.indexes = Array(base.indices.prefix(k.lowerBound))

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -177,7 +177,7 @@ extension Combinations: Equatable where Base: Equatable {}
 extension Combinations: Hashable where Base: Hashable {}
 
 //===----------------------------------------------------------------------===//
-// combinations(ofCounts:)
+// combinations(ofCount:)
 //===----------------------------------------------------------------------===//
 
 extension Collection {
@@ -188,7 +188,7 @@ extension Collection {
   /// four colors:
   ///
   ///     let colors = ["fuchsia", "cyan", "mauve", "magenta"]
-  ///     for combo in colors.combinations(ofCounts: 1...2) {
+  ///     for combo in colors.combinations(ofCount: 1...2) {
   ///         print(combo.joined(separator: ", "))
   ///     }
   ///     // fuchsia
@@ -242,17 +242,11 @@ extension Collection {
   /// - Complexity: O(1)
   @inlinable
   public func combinations<R: RangeExpression>(
-    ofCounts kRange: R
+    ofCount kRange: R
   ) -> Combinations<Self> where R.Bound == Int {
     return Combinations(self, kRange: kRange)
   }
-}
-
-//===----------------------------------------------------------------------===//
-// combinations(ofCount:)
-//===----------------------------------------------------------------------===//
-
-extension Collection {
+  
   /// Returns a collection of combinations of this collection's elements, with
   /// each combination having the specified number of elements.
   ///

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -20,13 +20,6 @@ public struct Combinations<Base: Collection> {
   @usableFromInline
   internal let kRange: Range<Int>?
   
-  /// Initializes a `Combinations` for all combinations of `base` of all sizes.
-  /// - Parameter base: The collection to iterate over for combinations.
-  @usableFromInline
-  internal init(_ base: Base) {
-    self.init(base, kRange: 0...)
-  }
-  
   /// Initializes a `Combinations` for all combinations of `base` of size `k`.
   /// - Parameters:
   ///   - base: The collection to iterate over for combinations.
@@ -184,51 +177,6 @@ extension Combinations: Equatable where Base: Equatable {}
 extension Combinations: Hashable where Base: Hashable {}
 
 //===----------------------------------------------------------------------===//
-// combinations()
-//===----------------------------------------------------------------------===//
-
-extension Collection {
-  /// Returns a collection of all the combinations of this collection's
-  /// elements, including the full collection and an empty collection
-  ///
-  /// This example prints the all the combinations from an array of letters:
-  ///
-  ///     let letters = ["A", "B", "C", "D"]
-  ///     for combo in letters.combinations() {
-  ///         print(combo.joined(separator: ", "))
-  ///     }
-  ///     //
-  ///     // A
-  ///     // B
-  ///     // C
-  ///     // D
-  ///     // A, B
-  ///     // A, C
-  ///     // A, D
-  ///     // B, C
-  ///     // B, D
-  ///     // C, D
-  ///     // A, B, C
-  ///     // A, B, D
-  ///     // A, C, D
-  ///     // B, C, D
-  ///     // A, B, C, D
-  ///
-  /// The returned collection presents combinations in a consistent order, where
-  /// the indices in each combination are in ascending lexicographical order,
-  /// and the size of the combinations are in increasing order.
-  /// That is, in the example above, the combinations in order are the elements
-  /// at `[]`, `[0]`, `[1]`, `[2]`, `[3]`, `[0, 1]`, `[0, 2]`, `[0, 3]`,
-  /// `[1, 2]`, `[1, 3]`, … `[0, 1, 2, 3]`.
-  ///
-  /// - Complexity: O(1)
-  @inlinable
-  public func combinations() -> Combinations<Self> {
-    return Combinations(self)
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // combinations(ofCounts:)
 //===----------------------------------------------------------------------===//
 
@@ -259,6 +207,30 @@ extension Collection {
   /// That is, in the example above, the combinations in order are the elements
   /// at `[0]`, `[1]`, `[2]`, `[3]`, `[0, 1]`, `[0, 2]`, `[0, 3]`, `[1, 2]`,
   /// `[1, 3]`, and finally `[2, 3]`.
+  ///
+  /// This example prints _all_ the combinations (including an empty array and
+  /// the original collection) from an array of numbers:
+  ///
+  ///     let numbers = [10, 20, 30, 40]
+  ///     for combo in numbers.combinations(ofCount: 0...) {
+  ///         print(combo)
+  ///     }
+  ///     // []
+  ///     // [10]
+  ///     // [20]
+  ///     // [30]
+  ///     // [40]
+  ///     // [10, 20]
+  ///     // [10, 30]
+  ///     // [10, 40]
+  ///     // [20, 30]
+  ///     // [20, 40]
+  ///     // [30, 40]
+  ///     // [10, 20, 30]
+  ///     // [10, 20, 40]
+  ///     // [10, 30, 40]
+  ///     // [20, 30, 40]
+  ///     // [10, 20, 30, 40]
   ///
   /// If `kRange` is `0...0`, the resulting sequence has exactly one element, an
   /// empty array. If `k.upperBound` is greater than the number of elements in

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -245,7 +245,9 @@ extension Collection {
   /// - Parameter kRange: The range of numbers of elements to include in each
   /// combination.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
+  /// is the number of elements in the base collection, since `Combinations`
+  /// accesses the `count` of the base collection.
   @inlinable
   public func combinations<R: RangeExpression>(
     ofCount kRange: R
@@ -279,7 +281,9 @@ extension Collection {
   ///
   /// - Parameter k: The number of elements to include in each combination.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
+  /// is the number of elements in the base collection, since `Combinations`
+  /// accesses the `count` of the base collection.
   @inlinable
   public func combinations(ofCount k: Int) -> Combinations<Self> {
     assert(k >= 0, "Can't have combinations with a negative number of elements.")

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -33,7 +33,6 @@ public struct Combinations<Base: Collection> {
   ///   - k: The expected size of each combination.
   @usableFromInline
   internal init(_ base: Base, k: Int) {
-    assert(k >= 0, "Can't have combinations with a negative number of elements.")
     self.init(base, k: k...k)
   }
   
@@ -307,6 +306,7 @@ extension Collection {
   /// - Complexity: O(1)
   @inlinable
   public func combinations(ofCount k: Int) -> Combinations<Self> {
+    assert(k >= 0, "Can't have combinations with a negative number of elements.")
     return Combinations(self, k: k)
   }
 }

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -22,7 +22,8 @@ public struct Combinations<Base: Collection> {
     self.base = base
     self.k = base.count < k ? -1 : k
   }
-
+  
+  /// The total number of combinations.
   @inlinable
   public var count: Int {
     func binomial(n: Int, k: Int) -> Int {

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -45,7 +45,7 @@ public struct Combinations<Base: Collection> {
   internal init<R: RangeExpression>(
     _ base: Base, k: R
   ) where R.Bound == Int {
-    let range = k.relative(to: R.Bound.zero..<R.Bound.max)
+    let range = k.relative(to: 0 ..< .max)
     self.base = base
     let upperBound = base.count + 1
     self.k = range.lowerBound < upperBound

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -124,7 +124,8 @@ extension Combinations: Sequence {
         if kRange.lowerBound < kRange.upperBound {
           let advancedLowerBound = kRange.lowerBound + 1
           kRange = advancedLowerBound..<kRange.upperBound
-          self.indexes = Array(base.indices.prefix(kRange.lowerBound))
+          indexes.removeAll(keepingCapacity: true)
+          indexes.append(contentsOf: base.indices.prefix(kRange.lowerBound))
         }
       }
       

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Algorithms open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -130,7 +130,7 @@ extension Combinations: Equatable where Base: Equatable {}
 extension Combinations: Hashable where Base: Hashable {}
 
 //===----------------------------------------------------------------------===//
-// combinations(count:)
+// combinations(ofCount:)
 //===----------------------------------------------------------------------===//
 
 extension Collection {

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -13,18 +13,37 @@ import XCTest
 import Algorithms
 
 final class CombinationsTests: XCTestCase {
+  func testCount() {
+    let c = "ABCD"
+    
+    let c0 = c.combinations(ofCount: 0).count
+    XCTAssertEqual(c0, 1)
+    
+    let c1 = c.combinations(ofCount: 1).count
+    XCTAssertEqual(c1, 4)
+    
+    let c2 = c.combinations(ofCount: 2).count
+    XCTAssertEqual(c2, 6)
+    
+    let c3 = c.combinations(ofCount: 3).count
+    XCTAssertEqual(c3, 4)
+    
+    let c4 = c.combinations(ofCount: 4).count
+    XCTAssertEqual(c4, 1)
+  }
+  
   func testCombinations() {
     let c = "ABCD"
-
+    
     let c1 = c.combinations(ofCount: 1)
     XCTAssertEqual(["A", "B", "C", "D"], c1.map { String($0) })
-
+    
     let c2 = c.combinations(ofCount: 2)
     XCTAssertEqual(["AB", "AC", "AD", "BC", "BD", "CD"], c2.map { String($0) })
-
+    
     let c3 = c.combinations(ofCount: 3)
     XCTAssertEqual(["ABC", "ABD", "ACD", "BCD"], c3.map { String($0) })
-
+    
     let c4 = c.combinations(ofCount: 4)
     XCTAssertEqual(["ABCD"], c4.map { String($0) })
   }
@@ -33,7 +52,7 @@ final class CombinationsTests: XCTestCase {
     // `k == 0` results in one zero-length combination
     XCTAssertEqualSequences([[]], "".combinations(ofCount: 0))
     XCTAssertEqualSequences([[]], "ABCD".combinations(ofCount: 0))
-
+    
     // `k` greater than element count results in zero combinations
     XCTAssertEqualSequences([], "".combinations(ofCount: 5))
     XCTAssertEqualSequences([], "ABCD".combinations(ofCount: 5))

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -64,7 +64,7 @@ final class CombinationsTests: XCTestCase {
     let c14 = c.combinations(ofCounts: ...3).count
     XCTAssertEqual(c14, 15)
     
-    let c15 = c.combinations().count
+    let c15 = c.combinations(ofCounts: 0...).count
     XCTAssertEqual(c15, 16)
   }
   
@@ -89,7 +89,7 @@ final class CombinationsTests: XCTestCase {
     let c6 = c.combinations(ofCounts: 0...4)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c6.map { String($0) })
     
-    let c7 = c.combinations()
+    let c7 = c.combinations(ofCounts: 0...)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c7.map { String($0) })
     
     let c8 = c.combinations(ofCounts: ...4)
@@ -121,6 +121,6 @@ final class CombinationsTests: XCTestCase {
     XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...3))
     XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...))
     XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: ...3))
-    XCTAssertLazySequence("ABC".lazy.combinations())
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 0...))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -30,6 +30,36 @@ final class CombinationsTests: XCTestCase {
     
     let c4 = c.combinations(ofCount: 4).count
     XCTAssertEqual(c4, 1)
+    
+    let c5 = c.combinations(ofCounts: 0...0).count
+    XCTAssertEqual(c5, 1)
+    
+    let c6 = c.combinations(ofCounts: 1...1).count
+    XCTAssertEqual(c6, 4)
+    
+    let c7 = c.combinations(ofCounts: 1...2).count
+    XCTAssertEqual(c7, 10)
+    
+    let c8 = c.combinations(ofCounts: 1...3).count
+    XCTAssertEqual(c8, 14)
+    
+    let c9 = c.combinations(ofCounts: 2...4).count
+    XCTAssertEqual(c9, 11)
+    
+    // `k` greater than element count results in same number of combinations
+    let c10 = c.combinations(ofCounts: 3...10).count
+    XCTAssertEqual(c10, 5)
+    
+    // `k` greater than element count results in same number of combinations
+    let c11 = c.combinations(ofCounts: 4...10).count
+    XCTAssertEqual(c11, 1)
+    
+    // `k` entirely greater than element count results in no combinations
+    let c12 = c.combinations(ofCounts: 5...10).count
+    XCTAssertEqual(c12, 0)
+    
+    let c13 = c.combinations().count
+    XCTAssertEqual(c13, 16)
   }
   
   func testCombinations() {
@@ -46,19 +76,31 @@ final class CombinationsTests: XCTestCase {
     
     let c4 = c.combinations(ofCount: 4)
     XCTAssertEqual(["ABCD"], c4.map { String($0) })
+    
+    let c5 = c.combinations(ofCounts: 2...4)
+    XCTAssertEqual(["ABCD", "ABC", "ABD", "ACD", "BCD", "AB", "AC", "AD", "BC", "BD", "CD"], c5.map { String($0) })
+    
+    let c6 = c.combinations()
+    XCTAssertEqual(["ABCD", "ABC", "ABD", "ACD", "BCD", "AB", "AC", "AD", "BC", "BD", "CD", "A", "B", "C", "D", ""], c6.map { String($0) })
   }
   
   func testEmpty() {
     // `k == 0` results in one zero-length combination
     XCTAssertEqualSequences([[]], "".combinations(ofCount: 0))
+    XCTAssertEqualSequences([[]], "".combinations(ofCounts: 0...0))
     XCTAssertEqualSequences([[]], "ABCD".combinations(ofCount: 0))
+    XCTAssertEqualSequences([[]], "ABCD".combinations(ofCounts: 0...0))
     
     // `k` greater than element count results in zero combinations
     XCTAssertEqualSequences([], "".combinations(ofCount: 5))
+    XCTAssertEqualSequences([], "".combinations(ofCounts: 5...10))
     XCTAssertEqualSequences([], "ABCD".combinations(ofCount: 5))
+    XCTAssertEqualSequences([], "ABCD".combinations(ofCounts: 5...10))
   }
   
   func testCombinationsLazy() {
     XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...3))
+    XCTAssertLazySequence("ABC".lazy.combinations())
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -58,8 +58,14 @@ final class CombinationsTests: XCTestCase {
     let c12 = c.combinations(ofCounts: 5...10).count
     XCTAssertEqual(c12, 0)
     
-    let c13 = c.combinations().count
+    let c13 = c.combinations(ofCounts: 0...).count
     XCTAssertEqual(c13, 16)
+    
+    let c14 = c.combinations(ofCounts: ...3).count
+    XCTAssertEqual(c14, 15)
+    
+    let c15 = c.combinations().count
+    XCTAssertEqual(c15, 16)
   }
   
   func testCombinations() {
@@ -81,7 +87,19 @@ final class CombinationsTests: XCTestCase {
     XCTAssertEqual(["AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c5.map { String($0) })
     
     let c6 = c.combinations(ofCounts: 0...4)
-    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD","ABCD"], c6.map { String($0) })
+    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c6.map { String($0) })
+    
+    let c7 = c.combinations()
+    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c7.map { String($0) })
+    
+    let c8 = c.combinations(ofCounts: ...4)
+    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c8.map { String($0) })
+    
+    let c9 = c.combinations(ofCounts: ...3)
+    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD"], c9.map { String($0) })
+    
+    let c10 = c.combinations(ofCounts: 1...)
+    XCTAssertEqual(["A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c10.map { String($0) })
   }
   
   func testEmpty() {
@@ -101,6 +119,8 @@ final class CombinationsTests: XCTestCase {
   func testCombinationsLazy() {
     XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1))
     XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...3))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: ...3))
     XCTAssertLazySequence("ABC".lazy.combinations())
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -78,10 +78,10 @@ final class CombinationsTests: XCTestCase {
     XCTAssertEqual(["ABCD"], c4.map { String($0) })
     
     let c5 = c.combinations(ofCounts: 2...4)
-    XCTAssertEqual(["ABCD", "ABC", "ABD", "ACD", "BCD", "AB", "AC", "AD", "BC", "BD", "CD"], c5.map { String($0) })
+    XCTAssertEqual(["AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c5.map { String($0) })
     
-    let c6 = c.combinations()
-    XCTAssertEqual(["ABCD", "ABC", "ABD", "ACD", "BCD", "AB", "AC", "AD", "BC", "BD", "CD", "A", "B", "C", "D", ""], c6.map { String($0) })
+    let c6 = c.combinations(ofCounts: 0...4)
+    XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD","ABCD"], c6.map { String($0) })
   }
   
   func testEmpty() {

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -31,40 +31,40 @@ final class CombinationsTests: XCTestCase {
     let c4 = c.combinations(ofCount: 4).count
     XCTAssertEqual(c4, 1)
     
-    let c5 = c.combinations(ofCounts: 0...0).count
+    let c5 = c.combinations(ofCount: 0...0).count
     XCTAssertEqual(c5, 1)
     
-    let c6 = c.combinations(ofCounts: 1...1).count
+    let c6 = c.combinations(ofCount: 1...1).count
     XCTAssertEqual(c6, 4)
     
-    let c7 = c.combinations(ofCounts: 1...2).count
+    let c7 = c.combinations(ofCount: 1...2).count
     XCTAssertEqual(c7, 10)
     
-    let c8 = c.combinations(ofCounts: 1...3).count
+    let c8 = c.combinations(ofCount: 1...3).count
     XCTAssertEqual(c8, 14)
     
-    let c9 = c.combinations(ofCounts: 2...4).count
+    let c9 = c.combinations(ofCount: 2...4).count
     XCTAssertEqual(c9, 11)
     
     // `k` greater than element count results in same number of combinations
-    let c10 = c.combinations(ofCounts: 3...10).count
+    let c10 = c.combinations(ofCount: 3...10).count
     XCTAssertEqual(c10, 5)
     
     // `k` greater than element count results in same number of combinations
-    let c11 = c.combinations(ofCounts: 4...10).count
+    let c11 = c.combinations(ofCount: 4...10).count
     XCTAssertEqual(c11, 1)
     
     // `k` entirely greater than element count results in no combinations
-    let c12 = c.combinations(ofCounts: 5...10).count
+    let c12 = c.combinations(ofCount: 5...10).count
     XCTAssertEqual(c12, 0)
     
-    let c13 = c.combinations(ofCounts: 0...).count
+    let c13 = c.combinations(ofCount: 0...).count
     XCTAssertEqual(c13, 16)
     
-    let c14 = c.combinations(ofCounts: ...3).count
+    let c14 = c.combinations(ofCount: ...3).count
     XCTAssertEqual(c14, 15)
     
-    let c15 = c.combinations(ofCounts: 0...).count
+    let c15 = c.combinations(ofCount: 0...).count
     XCTAssertEqual(c15, 16)
   }
   
@@ -83,44 +83,44 @@ final class CombinationsTests: XCTestCase {
     let c4 = c.combinations(ofCount: 4)
     XCTAssertEqual(["ABCD"], c4.map { String($0) })
     
-    let c5 = c.combinations(ofCounts: 2...4)
+    let c5 = c.combinations(ofCount: 2...4)
     XCTAssertEqual(["AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c5.map { String($0) })
     
-    let c6 = c.combinations(ofCounts: 0...4)
+    let c6 = c.combinations(ofCount: 0...4)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c6.map { String($0) })
     
-    let c7 = c.combinations(ofCounts: 0...)
+    let c7 = c.combinations(ofCount: 0...)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c7.map { String($0) })
     
-    let c8 = c.combinations(ofCounts: ...4)
+    let c8 = c.combinations(ofCount: ...4)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c8.map { String($0) })
     
-    let c9 = c.combinations(ofCounts: ...3)
+    let c9 = c.combinations(ofCount: ...3)
     XCTAssertEqual(["", "A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD"], c9.map { String($0) })
     
-    let c10 = c.combinations(ofCounts: 1...)
+    let c10 = c.combinations(ofCount: 1...)
     XCTAssertEqual(["A", "B", "C", "D", "AB", "AC", "AD", "BC", "BD", "CD", "ABC", "ABD", "ACD", "BCD", "ABCD"], c10.map { String($0) })
   }
   
   func testEmpty() {
     // `k == 0` results in one zero-length combination
     XCTAssertEqualSequences([[]], "".combinations(ofCount: 0))
-    XCTAssertEqualSequences([[]], "".combinations(ofCounts: 0...0))
+    XCTAssertEqualSequences([[]], "".combinations(ofCount: 0...0))
     XCTAssertEqualSequences([[]], "ABCD".combinations(ofCount: 0))
-    XCTAssertEqualSequences([[]], "ABCD".combinations(ofCounts: 0...0))
+    XCTAssertEqualSequences([[]], "ABCD".combinations(ofCount: 0...0))
     
     // `k` greater than element count results in zero combinations
     XCTAssertEqualSequences([], "".combinations(ofCount: 5))
-    XCTAssertEqualSequences([], "".combinations(ofCounts: 5...10))
+    XCTAssertEqualSequences([], "".combinations(ofCount: 5...10))
     XCTAssertEqualSequences([], "ABCD".combinations(ofCount: 5))
-    XCTAssertEqualSequences([], "ABCD".combinations(ofCounts: 5...10))
+    XCTAssertEqualSequences([], "ABCD".combinations(ofCount: 5...10))
   }
   
   func testCombinationsLazy() {
     XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1))
-    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...3))
-    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 1...))
-    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: ...3))
-    XCTAssertLazySequence("ABC".lazy.combinations(ofCounts: 0...))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1...3))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 1...))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCount: ...3))
+    XCTAssertLazySequence("ABC".lazy.combinations(ofCount: 0...))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CombinationsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Algorithms open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description
This addition adds the ability to easily get combinations of a range of sizes, instead of the previous behavior of a single, fixed size, `k`.

### Detailed Design
The `combinations(ofCount:)` function that takes a `RangeExpression` is added in an extension of `Collection`.

```swift
extension Collection {
  public func combinations<R: RangeExpression>(
    ofCount kRange: R
  ) -> Combinations<Self> where R.Bound == Int {
    return Combinations(self, kRange: kRange)
  }
}
```

If the upper bound of the range exceeds the length of the collection, no such combinations of those sizes will be returned, effectively clamping the range to `0...n` where `n` is the length of the collection. The behavior of negative numbers also remains unchanged (asserting).

This also updates the implementation of the existing `combinations(ofCount:)` function to initialize a `Combinations` with a range of `k...k` to provide the same functionality as it did before.

```swift
public struct Combinations<Base: Collection> {
  internal init(_ base: Base, k: Int) {
    self.init(base, kRange: k...k)
  }
 }
```

### Complexity
The complexity remains O(*1*) for initializing `Combinations`. Accessing the next combination also remains O(*1*).

### Naming
The name `combinations(ofCount:)` is the same as the original, but reflects the ability to provide multiple counts. Alternatively considered `combinations(ofCounts:)` and `combinations(ofCountsIn range:)`.

### Documentation Plan
The documentation in `Guides/Combinations.md` has been updated to reflect the new function. Inline code documentation also exists for each of the functions.

### Test Plan
- Adds tests for the `count` property, which was previously untested
- Adds tests for the outputs of a range of sizes
- Adds tests for all valid sizes
- Adds tests for ranges extending above the size of the collection

### Source Impact
The functionality is purely additive. The behavior of the existing function is unchanged.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
