### PR TITLE
Copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ package updates, you can specify your package dependency using
   the copying ended and an iterator for the source sequence after the elements
   that were copied.  The `copy(collection:)` method works like the previous
   method, but uses a collection as the source, and expresses the unread suffix
-  for that source as an `Index` instead.  The `copyOntoSuffix(with:)` and
-  `copyOntoSuffix(withCollection:)` methods work like the first two methods
+  for that source as an `Index` instead.  The `copy(asSuffix:)` and
+  `copy(collectionAsSuffix:)` methods work like the first two methods
   except the end of the receiver is overwritten instead of the beginning, and
   so their return value instead includes the starting index in the receiver
   where the copying began.  The `copy(backwards:)` method works like the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ package updates, you can specify your package dependency using
   where the copying began.  The `copy(backwards:)` method works like the
   previous method, except the source is also read from the end instead of the
   beginning, and so the return values are the starting indices of both
-  collections' targeted elements.
+  collections' targeted elements.  The Swift memory model restricts reading and
+  writing into the same collection, so the `copy(forwardsFrom:to:)` and
+  `copy(backwardsFrom:to:)` methods provide same-collection element copying.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ package updates, you can specify your package dependency using
 
 ## [Unreleased]
 
-*No changes yet.*
+### Additions
+
+- The `copy(from:)` method has been added, applying to types conforming to
+  `MutableCollection`.  It takes a sequence with the same element type as its
+  only parameter, whose elements will be copied on top of the existing
+  elements.  The return values are the past-the-end index in the receiver where
+  the copying ended and an iterator for the source sequence after the elements
+  that were copied.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ package updates, you can specify your package dependency using
   the copying ended and an iterator for the source sequence after the elements
   that were copied.  The `copy(collection:)` method works like the previous
   method, but uses a collection as the source, and expresses the unread suffix
-  for that source as an `Index` instead.
+  for that source as an `Index` instead.  The `copyOntoSuffix(with:)` and
+  `copyOntoSuffix(withCollection:)` methods work like the first two methods
+  except the end of the receiver is overwritten instead of the beginning, and
+  so their return value instead includes the starting index in the receiver
+  where the copying began.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ package updates, you can specify your package dependency using
   `copyOntoSuffix(withCollection:)` methods work like the first two methods
   except the end of the receiver is overwritten instead of the beginning, and
   so their return value instead includes the starting index in the receiver
-  where the copying began.
+  where the copying began.  The `copy(backwards:)` method works like the
+  previous method, except the source is also read from the end instead of the
+  beginning, and so the return values are the starting indices of both
+  collections' targeted elements.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ package updates, you can specify your package dependency using
   only parameter, whose elements will be copied on top of the existing
   elements.  The return values are the past-the-end index in the receiver where
   the copying ended and an iterator for the source sequence after the elements
-  that were copied.
+  that were copied.  The `copy(collection:)` method works like the previous
+  method, but uses a collection as the source, and expresses the unread suffix
+  for that source as an `Index` instead.
 
 ---
 

--- a/Guides/Copy.md
+++ b/Guides/Copy.md
@@ -20,7 +20,9 @@ values over the first `k` elements of the receiver, where `k` is the smaller of
 the two sequences' lengths.  The `copy(collection:)` variant uses a collection
 for the source sequence.  The `copyOntoSuffix(with:)` and
 `copyOntoSuffix(withCollection:)` methods work similar to the first two methods
-except the last `k` elements of the receiver are overlaid instead.
+except the last `k` elements of the receiver are overlaid instead.  The
+`copy(backwards:)` method is like the previous method, except both the source
+and destination collections are traversed from the end.
 
 ## Detailed Design
 
@@ -44,12 +46,16 @@ extension MutableCollection where Self: BidirectionalCollection {
     mutating func copyOntoSuffix<C>(withCollection source: C)
      -> (copyStart: Index, sourceTailStart: C.Index)
      where C : Collection, Self.Element == C.Element
+
+    mutating func copy<C>(backwards source: C)
+     -> (writtenStart: Index, readStart: C.Index)
+      where C : BidirectionalCollection, Self.Element == C.Element
 }
 ```
 
 The methods return two values.  The first member is the index of the receiver
 defining the non-anchored endpoint of the elements that were actually written
-over.  The second member is for reading the suffix of the source that wasn't
+over.  The second member is for reading the adfix of the source that wasn't
 actually used.
 
 ### Complexity
@@ -68,8 +74,12 @@ libraries.
 a bounding pair of input iterators for the source and a single output iterator
 for the destination, returning one-past the last output iterator written over.
 The `copy_if` function does not have an analogue, since it can be simulated by
-submitting the result from `filter(_:)` as the source.
+submitting the result from `filter(_:)` as the source.  There is a
+[`copy_backward`][C++CopyBackward] function that copies elements backwards from
+the far end of the source and destination, returning the near end of the
+destination that got written.
 
 <!-- Link references for other languages -->
 
 [C++Copy]: https://en.cppreference.com/w/cpp/algorithm/copy
+[C++CopyBackward]: https://en.cppreference.com/w/cpp/algorithm/copy_backward

--- a/Guides/Copy.md
+++ b/Guides/Copy.md
@@ -18,11 +18,11 @@ print(Array(IteratorSequence(sourceSuffix)))  // "[]"
 `copy(from:)` takes a source sequence and overlays its first *k* elements'
 values over the first `k` elements of the receiver, where `k` is the smaller of
 the two sequences' lengths.  The `copy(collection:)` variant uses a collection
-for the source sequence.  The `copyOntoSuffix(with:)` and
-`copyOntoSuffix(withCollection:)` methods work similar to the first two methods
-except the last `k` elements of the receiver are overlaid instead.  The
-`copy(backwards:)` method is like the previous method, except both the source
-and destination collections are traversed from the end.
+for the source sequence.  The `copy(asSuffix:)` and `copy(collectionAsSuffix:)`
+methods work similar to the first two methods except the last `k` elements of
+the receiver are overlaid instead.  The `copy(backwards:)` method is like the
+previous method, except both the source and destination collections are
+traversed from the end.
 
 Since the Swift memory model prevents a collection from being used multiple
 times in code where at least one use is mutable, the `copy(forwardsFrom:to:)`
@@ -49,11 +49,11 @@ extension MutableCollection {
 }
 
 extension MutableCollection where Self: BidirectionalCollection {
-    mutating func copyOntoSuffix<S>(with source: S)
+    mutating func copy<S>(asSuffix source: S)
      -> (copyStart: Index, sourceTail: S.Iterator)
      where S : Sequence, Self.Element == S.Element
 
-    mutating func copyOntoSuffix<C>(withCollection source: C)
+    mutating func copy<C>(collectionAsSuffix source: C)
      -> (copyStart: Index, sourceTailStart: C.Index)
      where C : Collection, Self.Element == C.Element
 

--- a/Guides/Copy.md
+++ b/Guides/Copy.md
@@ -18,7 +18,9 @@ print(Array(IteratorSequence(sourceSuffix)))  // "[]"
 `copy(from:)` takes a source sequence and overlays its first *k* elements'
 values over the first `k` elements of the receiver, where `k` is the smaller of
 the two sequences' lengths.  The `copy(collection:)` variant uses a collection
-for the source sequence.
+for the source sequence.  The `copyOntoSuffix(with:)` and
+`copyOntoSuffix(withCollection:)` methods work similar to the first two methods
+except the last `k` elements of the receiver are overlaid instead.
 
 ## Detailed Design
 
@@ -32,6 +34,16 @@ extension MutableCollection {
   mutating func copy<C>(collection: C)
    -> (copyEnd: Index, sourceTailStart: C.Index)
    where C : Collection, Self.Element == C.Element
+}
+
+extension MutableCollection where Self: BidirectionalCollection {
+    mutating func copyOntoSuffix<S>(with source: S)
+     -> (copyStart: Index, sourceTail: S.Iterator)
+     where S : Sequence, Self.Element == S.Element
+
+    mutating func copyOntoSuffix<C>(withCollection source: C)
+     -> (copyStart: Index, sourceTailStart: C.Index)
+     where C : Collection, Self.Element == C.Element
 }
 ```
 

--- a/Guides/Copy.md
+++ b/Guides/Copy.md
@@ -1,0 +1,58 @@
+# Copy
+
+[[Source](../Sources/Algorithms/Copy.swift) |
+ [Tests](../Tests/SwiftAlgorithmsTests/CopyTests.swift)]
+
+Copy a sequence onto an element-mutable collection.
+
+```swift
+var destination = [1, 2, 3, 4, 5]
+let source = [6, 7, 8, 9, 10]
+print(destination)  // "[1, 2, 3, 4, 5]
+
+let (_, sourceSuffix) = destination.copy(from: source)
+print(destination)  // "[6, 7, 8, 9, 10]"
+print(Array(IteratorSequence(sourceSuffix)))  // "[]"
+```
+
+`copy(from:)` takes a source sequence and overlays its first *k* elements'
+values over the first `k` elements of the receiver, where `k` is the smaller of
+the two sequences' lengths.
+
+## Detailed Design
+
+A new method is added to element-mutable collections:
+
+```swift
+extension MutableCollection {
+  mutating func copy<S: Sequence>(from source: S)
+   -> (copyEnd: Index, sourceTail: S.Iterator) where S.Element == Element
+}
+```
+
+The methods return two values.  The first member is the index of the receiver
+defining the non-anchored endpoint of the elements that were actually written
+over.  The second member is for reading the suffix of the source that wasn't
+actually used.
+
+### Complexity
+
+Calling these methods is O(_k_), where _k_ is the length of the shorter
+sequence between the receiver and `source`.
+
+### Naming
+
+This method’s name matches the term of art used in other languages and
+libraries.
+
+### Comparison with other languages
+
+**C++:** Has a [`copy`][C++Copy] function in the `algorithm` library that takes
+a bounding pair of input iterators for the source and a single output iterator
+for the destination, returning one-past the last output iterator written over.
+The `copy_if` function does not have an analogue, since it can be simulated by
+submitting the result from `filter(_:)` as the source.
+
+<!-- Link references for other languages -->
+
+[C++Copy]: https://en.cppreference.com/w/cpp/algorithm/copy

--- a/Guides/Copy.md
+++ b/Guides/Copy.md
@@ -17,16 +17,21 @@ print(Array(IteratorSequence(sourceSuffix)))  // "[]"
 
 `copy(from:)` takes a source sequence and overlays its first *k* elements'
 values over the first `k` elements of the receiver, where `k` is the smaller of
-the two sequences' lengths.
+the two sequences' lengths.  The `copy(collection:)` variant uses a collection
+for the source sequence.
 
 ## Detailed Design
 
-A new method is added to element-mutable collections:
+New methods are added to element-mutable collections:
 
 ```swift
 extension MutableCollection {
   mutating func copy<S: Sequence>(from source: S)
    -> (copyEnd: Index, sourceTail: S.Iterator) where S.Element == Element
+
+  mutating func copy<C>(collection: C)
+   -> (copyEnd: Index, sourceTailStart: C.Index)
+   where C : Collection, Self.Element == C.Element
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
+- [`copy(from:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
-- [`copy(from:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
+- [`copy(from:)`, `copy(collection:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
-- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`, `copy(backwards:)`, `copy(forwardsFrom:to:)`, `copy(backwardsFrom:to:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
+- [`copy(from:)`, `copy(collection:)`, `copy(asSuffix:)`, `copy(collectionAsSuffix:)`, `copy(backwards:)`, `copy(forwardsFrom:to:)`, `copy(backwardsFrom:to:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
-- [`copy(from:)`, `copy(collection:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
+- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
-- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`, `copy(backwards:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
+- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`, `copy(backwards:)`, `copy(forwardsFrom:to:)`, `copy(backwardsFrom:to:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`rotate(toStartAt:)`, `rotate(subrange:toStartAt:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Rotate.md): In-place rotation of elements.
 - [`stablePartition(by:)`, `stablePartition(subrange:by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Partition.md): A partition that preserves the relative order of the resulting prefix and suffix.
-- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
+- [`copy(from:)`, `copy(collection:)`, `copyOntoSuffix(with:)`, `copyOntoSuffix(withCollection:)`, `copy(backwards:)`](./Guides/Copy.md): Copying from a sequence via overwriting elements.
 
 #### Combining collections
 

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-// copy(from:)
+// copy(from:), copy(collection:)
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection {
@@ -29,7 +29,7 @@ extension MutableCollection {
   ///   elements of `source` that where not used as part of the copying.  It
   ///   will be empty if every element was used.
   /// - Postcondition: Let *k* be the element count of the shorter of `self` and
-  ///   source.  Then `prefix(k)` will be equivalent to `source.prefix(k)`,
+  ///   `source`.  Then `prefix(k)` will be equivalent to `source.prefix(k)`,
   ///   while `dropFirst(k)` is unchanged.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
@@ -44,5 +44,38 @@ extension MutableCollection {
       formIndex(after: &current)
     }
     return (current, iterator)
+  }
+
+  /// Copies the elements from the given collection on top of the elements of
+  /// this collection, until the shorter one is exhausted.
+  ///
+  /// If you want to limit how much of this collection can be overrun, call this
+  /// method on the limiting subsequence instead.
+  ///
+  /// - Parameters:
+  ///   - collection: The collection to read the replacement values from.
+  /// - Returns: A two-member tuple where the first member is the index of the
+  ///   first element of this collection that was not assigned a copy and the
+  ///   second member is the index of the first element of `source` that was not
+  ///   used for the source of a copy.  They will be their collection's
+  ///   `startIndex` if no copying was done and their collection's `endIndex` if
+  ///   every element of that collection participated in a copy.
+  /// - Postcondition: Let *k* be the element count of the shorter of `self` and
+  ///   `source`.  Then `prefix(k)` will be equivalent to `source.prefix(k)`,
+  ///   while `dropFirst(k)` is unchanged.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  ///   between `self` and `source`.
+  public mutating func copy<C: Collection>(
+    collection: C
+  ) -> (copyEnd: Index, sourceTailStart: C.Index) where C.Element == Element {
+    var selfIndex = startIndex, collectionIndex = collection.startIndex
+    let end = endIndex, sourceEnd = collection.endIndex
+    while selfIndex < end, collectionIndex < sourceEnd {
+      self[selfIndex] = collection[collectionIndex]
+      formIndex(after: &selfIndex)
+      collection.formIndex(after: &collectionIndex)
+    }
+    return (selfIndex, collectionIndex)
   }
 }

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -56,16 +56,16 @@ extension MutableCollection {
   ///   - collection: The collection to read the replacement values from.
   /// - Returns: A two-member tuple where the first member is the index of the
   ///   first element of this collection that was not assigned a copy and the
-  ///   second member is the index of the first element of `source` that was not
-  ///   used for the source of a copy.  They will be their collection's
+  ///   second member is the index of the first element of `collection` that was
+  ///   not used for the source of a copy.  They will be their collection's
   ///   `startIndex` if no copying was done and their collection's `endIndex` if
   ///   every element of that collection participated in a copy.
   /// - Postcondition: Let *k* be the element count of the shorter of `self` and
-  ///   `source`.  Then `prefix(k)` will be equivalent to `source.prefix(k)`,
-  ///   while `dropFirst(k)` is unchanged.
+  ///   `collection`.  Then `prefix(k)` will be equivalent to
+  ///   `collection.prefix(k)`, while `dropFirst(k)` is unchanged.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
-  ///   between `self` and `source`.
+  ///   between `self` and `collection`.
   public mutating func copy<C: Collection>(
     collection: C
   ) -> (copyEnd: Index, sourceTailStart: C.Index) where C.Element == Element {

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -79,3 +79,77 @@ extension MutableCollection {
     return (selfIndex, collectionIndex)
   }
 }
+
+//===----------------------------------------------------------------------===//
+// copyOntoSuffix(with:), copyOntoSuffix(withCollection:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection where Self: BidirectionalCollection {
+  /// Copies the elements from the given sequence on top of the elements at the
+  /// end of this collection, until the shorter one is exhausted.
+  ///
+  /// If you want to limit how much of this collection can be overrun, call this
+  /// method on the limiting subsequence instead.  The elements in the mutated
+  /// suffix stay in the same order as they were in `source`.
+  ///
+  /// - Parameters:
+  ///   - source: The sequence to read the replacement values from.
+  /// - Returns: A two-member tuple where the first member is the index of the
+  ///   earliest element of this collection that was assigned a copy.  It will
+  ///   be `endIndex` if no copying was done and `startIndex` if every element
+  ///   was written over.  The second member is an iterator covering all the
+  ///   elements of `source` that where not used as part of the copying.  It
+  ///   will be empty if every element was used.
+  /// - Postcondition: Let *k* be the element count of the shorter of `self` and
+  ///   `source`.  Then `suffix(k)` will be equivalent to `source.prefix(k)`,
+  ///   while `dropLast(k)` is unchanged.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  ///   between `self` and `source`.
+  public mutating func copyOntoSuffix<S: Sequence>(
+    with source: S
+  ) -> (copyStart: Index, sourceTail: S.Iterator) where S.Element == Element {
+    var current = endIndex, iterator = source.makeIterator()
+    let start = startIndex
+    while current > start, let source = iterator.next() {
+      formIndex(before: &current)
+      self[current] = source
+    }
+    self[current...].reverse()
+    return (current, iterator)
+  }
+
+  /// Copies the elements from the given collection on top of the elements at
+  /// the end of this collection, until the shorter one is exhausted.
+  ///
+  /// If you want to limit how much of this collection can be overrun, call this
+  /// method on the limiting subsequence instead.  The elements in the mutated
+  /// suffix stay in the same order as they were in `source`.
+  ///
+  /// - Parameters:
+  ///   - source: The collection to read the replacement values from.
+  /// - Returns: A two-member tuple.  The first member is the index of the
+  ///   earliest element of this collection that was assigned a copy; or
+  ///   `endIndex` if no copying was done.  The second member is the index
+  ///   immediately after the latest element of `source` read for a copy; or
+  ///   `startIndex` if no copying was done.
+  /// - Postcondition: Let *k* be the element count of the shorter of `self` and
+  ///   `source`.  Then `suffix(k)` will be equivalent to `source.prefix(k)`,
+  ///   while `dropLast(k)` is unchanged.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  ///   between `self` and `source`.
+  public mutating func copyOntoSuffix<C: Collection>(
+    withCollection source: C
+  ) -> (copyStart: Index, sourceTailStart: C.Index) where C.Element == Element {
+    var selfIndex = endIndex, sourceIndex = source.startIndex
+    let start = startIndex, sourceEnd = source.endIndex
+    while selfIndex > start, sourceIndex < sourceEnd {
+      formIndex(before: &selfIndex)
+      self[selfIndex] = source[sourceIndex]
+      source.formIndex(after: &sourceIndex)
+    }
+    self[selfIndex...].reverse()
+    return (selfIndex, sourceIndex)
+  }
+}

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// copy(from:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection {
+  /// Copies the elements from the given sequence on top of the elements of this
+  /// collection, until the shorter one is exhausted.
+  ///
+  /// If you want to limit how much of this collection can be overrun, call this
+  /// method on the limiting subsequence instead.
+  ///
+  /// - Parameters:
+  ///   - source: The sequence to read the replacement values from.
+  /// - Returns: A two-member tuple where the first member is the index of the
+  ///   first element of this collection that was not assigned a copy.  It will
+  ///   be `startIndex` if no copying was done and `endIndex` if every element
+  ///   was written over.  The second member is an iterator covering all the
+  ///   elements of `source` that where not used as part of the copying.  It
+  ///   will be empty if every element was used.
+  /// - Postcondition: Let *k* be the element count of the shorter of `self` and
+  ///   source.  Then `prefix(k)` will be equivalent to `source.prefix(k)`,
+  ///   while `dropFirst(k)` is unchanged.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  ///   between `self` and `source`.
+  public mutating func copy<S: Sequence>(
+    from source: S
+  ) -> (copyEnd: Index, sourceTail: S.Iterator) where S.Element == Element {
+    var current = startIndex, iterator = source.makeIterator()
+    let end = endIndex
+    while current < end, let source = iterator.next() {
+      self[current] = source
+      formIndex(after: &current)
+    }
+    return (current, iterator)
+  }
+}

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -14,11 +14,12 @@
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection {
-  /// Copies the elements from the given sequence on top of the elements of this
-  /// collection, until the shorter one is exhausted.
+  /// Copies the prefix of the given sequence on top of the prefix of this
+  /// collection.
   ///
-  /// If you want to limit how much of this collection can be overrun, call this
-  /// method on the limiting subsequence instead.
+  /// Copying stops when the end of the shorter sequence is reached.  If you
+  /// want to limit how much of this collection can be overrun, call this method
+  /// on the limiting subsequence instead.
   ///
   /// - Parameters:
   ///   - source: The sequence to read the replacement values from.
@@ -46,11 +47,12 @@ extension MutableCollection {
     return (current, iterator)
   }
 
-  /// Copies the elements from the given collection on top of the elements of
-  /// this collection, until the shorter one is exhausted.
+  /// Copies the prefix of the given collection on top of the prefix of this
+  /// collection.
   ///
-  /// If you want to limit how much of this collection can be overrun, call this
-  /// method on the limiting subsequence instead.
+  /// Copying stops when the end of the shorter collection is reached.  If you
+  /// want to limit how much of this collection can be overrun, call this method
+  /// on the limiting subsequence instead.
   ///
   /// - Parameters:
   ///   - collection: The collection to read the replacement values from.
@@ -64,7 +66,7 @@ extension MutableCollection {
   ///   `collection`.  Then `prefix(k)` will be equivalent to
   ///   `collection.prefix(k)`, while `dropFirst(k)` is unchanged.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  /// - Complexity: O(*n*), where *n* is the length of the shorter collection
   ///   between `self` and `collection`.
   public mutating func copy<C: Collection>(
     collection: C
@@ -124,17 +126,19 @@ extension MutableCollection {
 }
 
 //===----------------------------------------------------------------------===//
-// copyOntoSuffix(with:), copyOntoSuffix(withCollection:), copy(backwards:),
+// copy(asSuffix:), copy(collectionAsSuffix:), copy(backwards:),
 // copy(backwardsFrom:to:)
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection where Self: BidirectionalCollection {
-  /// Copies the elements from the given sequence on top of the elements at the
-  /// end of this collection, until the shorter one is exhausted.
+  /// Copies the prefix of the given sequence on top of the suffix of this
+  /// collection.
   ///
-  /// If you want to limit how much of this collection can be overrun, call this
-  /// method on the limiting subsequence instead.  The elements in the mutated
-  /// suffix stay in the same order as they were in `source`.
+  /// Copying stops when either the sequence is exhausted or every element of
+  /// this collection is touched.  If you want to limit how much of this
+  /// collection can be overrun, call this method on the limiting subsequence
+  /// instead.  The elements in the mutated suffix preserve the order they had
+  /// in `source`.
   ///
   /// - Parameters:
   ///   - source: The sequence to read the replacement values from.
@@ -150,8 +154,8 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
   ///   between `self` and `source`.
-  public mutating func copyOntoSuffix<S: Sequence>(
-    with source: S
+  public mutating func copy<S: Sequence>(
+    asSuffix source: S
   ) -> (copyStart: Index, sourceTail: S.Iterator) where S.Element == Element {
     var current = endIndex, iterator = source.makeIterator()
     let start = startIndex
@@ -163,12 +167,13 @@ extension MutableCollection where Self: BidirectionalCollection {
     return (current, iterator)
   }
 
-  /// Copies the elements from the given collection on top of the elements at
-  /// the end of this collection, until the shorter one is exhausted.
+  /// Copies the prefix of the given collection on top of the suffix of this
+  /// collection.
   ///
-  /// If you want to limit how much of this collection can be overrun, call this
-  /// method on the limiting subsequence instead.  The elements in the mutated
-  /// suffix stay in the same order as they were in `source`.
+  /// Copying stops when at least one of the collections has had all of its
+  /// elements touched.  If you want to limit how much of this collection can be
+  /// overrun, call this method on the limiting subsequence instead.  The
+  /// elements in the mutated suffix preserve the order they had in `source`.
   ///
   /// - Parameters:
   ///   - source: The collection to read the replacement values from.
@@ -181,10 +186,10 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///   `source`.  Then `suffix(k)` will be equivalent to `source.prefix(k)`,
   ///   while `dropLast(k)` is unchanged.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of the shorter sequence
+  /// - Complexity: O(*n*), where *n* is the length of the shorter collection
   ///   between `self` and `source`.
-  public mutating func copyOntoSuffix<C: Collection>(
-    withCollection source: C
+  public mutating func copy<C: Collection>(
+    collectionAsSuffix source: C
   ) -> (copyStart: Index, sourceTailStart: C.Index) where C.Element == Element {
     var selfIndex = endIndex, sourceIndex = source.startIndex
     let start = startIndex, sourceEnd = source.endIndex
@@ -197,12 +202,12 @@ extension MutableCollection where Self: BidirectionalCollection {
     return (selfIndex, sourceIndex)
   }
 
-  /// Copies the elements from the given collection on top of the elements of
-  /// this collection, going backwards from the ends of both collections, until
-  /// the shorter one is exhausted.
+  /// Copies the suffix of the given collection on top of the suffix of this
+  /// collection.
   ///
-  /// If you want to limit how much of this collection can be overrun, call this
-  /// method on the limiting subsequence instead.
+  /// Copying occurs backwards, and stops when the beginning of the shorter
+  /// collection is reached.  If you want to limit how much of this collection
+  /// can be overrun, call this method on the limiting subsequence instead.
   ///
   /// - Parameters:
   ///   - source: The collection to read the replacement values from.

--- a/Sources/Algorithms/Copy.swift
+++ b/Sources/Algorithms/Copy.swift
@@ -81,7 +81,7 @@ extension MutableCollection {
 }
 
 //===----------------------------------------------------------------------===//
-// copyOntoSuffix(with:), copyOntoSuffix(withCollection:)
+// copyOntoSuffix(with:), copyOntoSuffix(withCollection:), copy(backwards:)
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection where Self: BidirectionalCollection {
@@ -150,6 +150,39 @@ extension MutableCollection where Self: BidirectionalCollection {
       source.formIndex(after: &sourceIndex)
     }
     self[selfIndex...].reverse()
+    return (selfIndex, sourceIndex)
+  }
+
+  /// Copies the elements from the given collection on top of the elements of
+  /// this collection, going backwards from the ends of both collections, until
+  /// the shorter one is exhausted.
+  ///
+  /// If you want to limit how much of this collection can be overrun, call this
+  /// method on the limiting subsequence instead.
+  ///
+  /// - Parameters:
+  ///   - source: The collection to read the replacement values from.
+  /// - Returns: A two-member tuple.  The first member is the index of the
+  ///   earliest element of this collection that was assigned a copy.  The
+  ///   second member is the index of the earliest element of `source` that was
+  ///   read for copying.  If no copying was done, both returned indices are at
+  ///   their respective owner's `endIndex`.
+  /// - Postcondition: Let *k* be the element count of the shorter of `self` and
+  ///   `source`.  Then `suffix(k)` will be equivalent to `source.suffix(k)`,
+  ///   while `dropLast(k)` is unchanged.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the shorter collection
+  ///   between `self` and `source`.
+  public mutating func copy<C: BidirectionalCollection>(
+    backwards source: C
+  ) -> (writtenStart: Index, readStart: C.Index) where C.Element == Element {
+    var selfIndex = endIndex, sourceIndex = source.endIndex
+    let start = startIndex, sourceStart = source.startIndex
+    while selfIndex > start, sourceIndex > sourceStart {
+      formIndex(before: &selfIndex)
+      source.formIndex(before: &sourceIndex)
+      self[selfIndex] = source[sourceIndex]
+    }
     return (selfIndex, sourceIndex)
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -338,4 +338,134 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination[3..<7][result7.writtenStart...],
                             source4[result7.readStart...])
   }
+
+  /// Test forward copying within a collection.
+  func testInternalForward() {
+    // Empty source and destination
+    let untarnished = (0..<10).map(Double.init)
+    var sample = untarnished,
+        sRange, dRange: Range<Int>
+    XCTAssertEqualSequences(sample, untarnished)
+    (sRange, dRange) = sample.copy(forwardsFrom: 1..<1, to: 6..<6)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 1..<1)
+    XCTAssertEqual(dRange, 6..<6)
+
+    // Empty source
+    (sRange, dRange) = sample.copy(forwardsFrom: 2..<2, to: 7..<8)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 2..<2)
+    XCTAssertEqual(dRange, 7..<7)
+
+    // Empty destination
+    (sRange, dRange) = sample.copy(forwardsFrom: 3..<4, to: 9..<9)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 3..<3)
+    XCTAssertEqual(dRange, 9..<9)
+
+    // Equal nonempty source and destination
+    (sRange, dRange) = sample.copy(forwardsFrom: 5..<8, to: 5..<8)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 5..<8)
+    XCTAssertEqual(dRange, 5..<8)
+
+    // Overlapping nonempty source and destination
+    (sRange, dRange) = sample.copy(forwardsFrom: 5..<9, to: 3..<7)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 5, 6, 7, 8, 7, 8, 9])
+    XCTAssertEqual(sRange, 5..<9)
+    XCTAssertEqual(dRange, 3..<7)
+
+    // Disjoint but nonempty equal-sized source and destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(forwardsFrom: 7..<9, to: 2..<4)
+    XCTAssertEqualSequences(sample, [0, 1, 7, 8, 4, 5, 6, 7, 8, 9])
+    XCTAssertEqual(sRange, 7..<9)
+    XCTAssertEqual(dRange, 2..<4)
+
+    // Source longer than nonempty destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(forwardsFrom: 2..<6, to: 7..<10)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 3, 4, 5, 6, 2, 3, 4])
+    XCTAssertEqual(sRange, 2..<5)
+    XCTAssertEqual(dRange, 7..<10)
+
+    // Nonempty source shorter than destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(forwardsFrom: 5..<7, to: 1..<9)
+    XCTAssertEqualSequences(sample, [0, 5, 6, 3, 4, 5, 6, 7, 8, 9])
+    XCTAssertEqual(sRange, 5..<7)
+    XCTAssertEqual(dRange, 1..<3)
+
+    // Using expressions other than `Range`
+    sample = untarnished
+    (sRange, dRange) = sample.copy(forwardsFrom: ..<2, to: 8...)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1])
+    XCTAssertEqual(sRange, 0..<2)
+    XCTAssertEqual(dRange, 8..<10)
+  }
+
+  /// Test backward copying within a collection.
+  func testInternalBackward() {
+    // Empty source and destination
+    let untarnished = (0..<10).map(Double.init)
+    var sample = untarnished,
+        sRange, dRange: Range<Int>
+    XCTAssertEqualSequences(sample, untarnished)
+    (sRange, dRange) = sample.copy(backwardsFrom: 1..<1, to: 6..<6)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 1..<1)
+    XCTAssertEqual(dRange, 6..<6)
+
+    // Empty source
+    (sRange, dRange) = sample.copy(backwardsFrom: 2..<2, to: 7..<8)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 2..<2)
+    XCTAssertEqual(dRange, 8..<8)
+
+    // Empty destination
+    (sRange, dRange) = sample.copy(backwardsFrom: 3..<4, to: 9..<9)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 4..<4)
+    XCTAssertEqual(dRange, 9..<9)
+
+    // Equal nonempty source and destination
+    (sRange, dRange) = sample.copy(backwardsFrom: 5..<8, to: 5..<8)
+    XCTAssertEqualSequences(sample, untarnished)
+    XCTAssertEqual(sRange, 5..<8)
+    XCTAssertEqual(dRange, 5..<8)
+
+    // Overlapping nonempty source and destination
+    (sRange, dRange) = sample.copy(backwardsFrom: 3..<7, to: 5..<9)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 3, 4, 3, 4, 5, 6, 9])
+    XCTAssertEqual(sRange, 3..<7)
+    XCTAssertEqual(dRange, 5..<9)
+
+    // Disjoint but nonempty equal-sized source and destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(backwardsFrom: 7..<9, to: 2..<4)
+    XCTAssertEqualSequences(sample, [0, 1, 7, 8, 4, 5, 6, 7, 8, 9])
+    XCTAssertEqual(sRange, 7..<9)
+    XCTAssertEqual(dRange, 2..<4)
+
+    // Source longer than nonempty destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(backwardsFrom: 2..<6, to: 7..<10)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 3, 4, 5, 6, 3, 4, 5])
+    XCTAssertEqual(sRange, 3..<6)
+    XCTAssertEqual(dRange, 7..<10)
+
+    // Nonempty source shorter than destination
+    sample = untarnished
+    (sRange, dRange) = sample.copy(backwardsFrom: 5..<7, to: 1..<9)
+    XCTAssertEqualSequences(sample, [0, 1, 2, 3, 4, 5, 6, 5, 6, 9])
+    XCTAssertEqual(sRange, 5..<7)
+    XCTAssertEqual(dRange, 7..<9)
+
+    // Using expressions other than `Range`
+    sample = untarnished
+    (sRange, dRange) = sample.copy(backwardsFrom: 8..., to: ..<2)
+    XCTAssertEqualSequences(sample, [8, 9, 2, 3, 4, 5, 6, 7, 8, 9])
+    XCTAssertEqual(sRange, 8..<10)
+    XCTAssertEqual(dRange, 0..<2)
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+/// Unit tests for the `copy(from:)` method.
+final class CopyTests: XCTestCase {
+  /// Test empty source and destination.
+  func testBothEmpty() {
+    var empty1 = EmptyCollection<Double>()
+    let empty2 = EmptyCollection<Double>()
+    XCTAssertEqualSequences(empty1, [])
+
+    let result = empty1.copy(from: empty2)
+    XCTAssertEqual(result.copyEnd, empty1.startIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(empty1, [])
+  }
+
+  /// Test nonempty source and empty destination.
+  func testOnlyDestinationEmpty() {
+    var empty = EmptyCollection<Double>()
+    let single = CollectionOfOne(1.1)
+    XCTAssertEqualSequences(empty, [])
+
+    let result = empty.copy(from: single)
+    XCTAssertEqual(result.copyEnd, empty.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [1.1])
+    XCTAssertEqualSequences(empty, [])
+  }
+
+  /// Test empty source and nonempty destination.
+  func testOnlySourceEmpty() {
+    var single = CollectionOfOne(2.2)
+    let empty = EmptyCollection<Double>()
+    XCTAssertEqualSequences(single, [2.2])
+
+    let result = single.copy(from: empty)
+    XCTAssertEqual(result.copyEnd, single.startIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(single, [2.2])
+  }
+
+  /// Test two one-element collections.
+  func testTwoSingles() {
+    var destination = CollectionOfOne(3.3)
+    let source = CollectionOfOne(4.4)
+    XCTAssertEqualSequences(destination, [3.3])
+
+    let result = destination.copy(from: source)
+    XCTAssertEqual(result.copyEnd, destination.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(destination, [4.4])
+  }
+
+  /// Test two equal-length multi-element collections.
+  func testTwoWithEqualLength() {
+    var destination = Array("ABCDE")
+    let source = "fghij"
+    XCTAssertEqualSequences(destination, "ABCDE")
+
+    let result = destination.copy(from: source)
+    XCTAssertEqual(result.copyEnd, destination.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(destination, "fghij")
+  }
+
+  /// Test a source longer than a multi-element destination.
+  func testLongerDestination() {
+    var destination = Array(1...5)
+    let source = 10...100
+    XCTAssertEqualSequences(destination, 1...5)
+
+    let result = destination.copy(from: source)
+    XCTAssertEqual(result.copyEnd, destination.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), 15...100)
+    XCTAssertEqualSequences(destination, 10..<15)
+  }
+
+  /// Test a multi-element source shorter than the destination.
+  func testShorterDestination() {
+    var destination = Array("abcdefghijklm")
+    let source = "NOPQR"
+    XCTAssertEqualSequences(destination, "abcdefghijklm")
+
+    let result = destination.copy(from: source)
+    XCTAssertEqual(result.copyEnd, destination.index(destination.startIndex,
+                                                 offsetBy: source.count))
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(destination, "NOPQRfghijklm")
+  }
+
+  /// Test copying over part of the destination.
+  func testPartial() {
+    var destination = Array("abcdefghijklm")
+    let source = "STUVWXYZ"
+    XCTAssertEqualSequences(destination, "abcdefghijklm")
+
+    let result = destination[3..<7].copy(from: source)
+    XCTAssertEqual(result.copyEnd, 7)
+    XCTAssertEqualSequences(IteratorSequence(result.sourceTail), "WXYZ")
+    XCTAssertEqualSequences(destination, "abcSTUVhijklm")
+
+    let result2 = destination[3..<7].copy(from: "12")
+    XCTAssertEqual(result2.copyEnd, 5)
+    XCTAssertEqualSequences(IteratorSequence(result2.sourceTail), [])
+    XCTAssertEqualSequences(destination, "abc12UVhijklm")
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import Algorithms
 
-/// Unit tests for the `copy(from:)` and `copy(collection:)` methods.
+/// Unit tests for the `copy` and `copyOntoSuffix` methods.
 final class CopyTests: XCTestCase {
   /// Test empty source and destination.
   func testBothEmpty() {
@@ -29,6 +29,20 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, empty1.startIndex)
     XCTAssertEqual(result2.sourceTailStart, empty2.startIndex)
     XCTAssertEqualSequences(empty1, [])
+    XCTAssertEqualSequences(empty1[..<result2.copyEnd],
+                            empty2[..<result2.sourceTailStart])
+
+    let result3 = empty1.copyOntoSuffix(with: empty2)
+    XCTAssertEqual(result3.copyStart, empty1.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
+    XCTAssertEqualSequences(empty1, [])
+
+    let result4 = empty1.copyOntoSuffix(withCollection: empty2)
+    XCTAssertEqual(result4.copyStart, empty1.endIndex)
+    XCTAssertEqual(result4.sourceTailStart, empty2.startIndex)
+    XCTAssertEqualSequences(empty1, [])
+    XCTAssertEqualSequences(empty1[result4.copyStart...],
+                            empty2[..<result4.sourceTailStart])
   }
 
   /// Test nonempty source and empty destination.
@@ -46,6 +60,20 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, empty.startIndex)
     XCTAssertEqual(result2.sourceTailStart, single.startIndex)
     XCTAssertEqualSequences(empty, [])
+    XCTAssertEqualSequences(empty[..<result2.copyEnd],
+                            single[..<result2.sourceTailStart])
+
+    let result3 = empty.copyOntoSuffix(with: single)
+    XCTAssertEqual(result3.copyStart, empty.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [1.1])
+    XCTAssertEqualSequences(empty, [])
+
+    let result4 = empty.copyOntoSuffix(withCollection: single)
+    XCTAssertEqual(result4.copyStart, empty.endIndex)
+    XCTAssertEqual(result4.sourceTailStart, single.startIndex)
+    XCTAssertEqualSequences(empty, [])
+    XCTAssertEqualSequences(empty[result4.copyStart...],
+                            single[..<result4.sourceTailStart])
   }
 
   /// Test empty source and nonempty destination.
@@ -63,6 +91,20 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, single.startIndex)
     XCTAssertEqual(result2.sourceTailStart, empty.startIndex)
     XCTAssertEqualSequences(single, [2.2])
+    XCTAssertEqualSequences(single[..<result2.copyEnd],
+                            empty[..<result2.sourceTailStart])
+
+    let result3 = single.copyOntoSuffix(with: empty)
+    XCTAssertEqual(result3.copyStart, single.endIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
+    XCTAssertEqualSequences(single, [2.2])
+
+    let result4 = single.copyOntoSuffix(withCollection: empty)
+    XCTAssertEqual(result4.copyStart, single.endIndex)
+    XCTAssertEqual(result4.sourceTailStart, empty.startIndex)
+    XCTAssertEqualSequences(single, [2.2])
+    XCTAssertEqualSequences(single[result4.copyStart...],
+                            empty[..<result4.sourceTailStart])
   }
 
   /// Test two one-element collections.
@@ -81,6 +123,22 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, destination.endIndex)
     XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
     XCTAssertEqualSequences(destination, [5.5])
+    XCTAssertEqualSequences(destination[..<result2.copyEnd],
+                            source2[..<result2.sourceTailStart])
+
+    let source3 = CollectionOfOne(6.6),
+        result3 = destination.copyOntoSuffix(with: source3)
+    XCTAssertEqual(result3.copyStart, destination.startIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
+    XCTAssertEqualSequences(destination, [6.6])
+
+    let source4 = CollectionOfOne(7.7),
+        result4 = destination.copyOntoSuffix(withCollection: source4)
+    XCTAssertEqual(result4.copyStart, destination.startIndex)
+    XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
+    XCTAssertEqualSequences(destination, [7.7])
+    XCTAssertEqualSequences(destination[result4.copyStart...],
+                            source4[..<result4.sourceTailStart])
   }
 
   /// Test two equal-length multi-element collections.
@@ -98,6 +156,21 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, destination.endIndex)
     XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
     XCTAssertEqualSequences(destination, "12345")
+    XCTAssertEqualSequences(destination[..<result2.copyEnd],
+                            source2[..<result2.sourceTailStart])
+
+    let source3 = "KLMNO", result3 = destination.copyOntoSuffix(with: source3)
+    XCTAssertEqual(result3.copyStart, destination.startIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
+    XCTAssertEqualSequences(destination, "KLMNO")
+
+    let source4 = "67890",
+        result4 = destination.copyOntoSuffix(withCollection: source4)
+    XCTAssertEqual(result4.copyStart, destination.startIndex)
+    XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
+    XCTAssertEqualSequences(destination, "67890")
+    XCTAssertEqualSequences(destination[result4.copyStart...],
+                            source4[..<result4.sourceTailStart])
   }
 
   /// Test a source longer than a multi-element destination.
@@ -115,6 +188,21 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, destination.endIndex)
     XCTAssertEqual(result2.sourceTailStart, -45)
     XCTAssertEqualSequences(destination, (-50)...(-46))
+    XCTAssertEqualSequences(destination[..<result2.copyEnd],
+                            source2[..<result2.sourceTailStart])
+
+    let source3 = 200..<300, result3 = destination.copyOntoSuffix(with: source3)
+    XCTAssertEqual(result3.copyStart, destination.startIndex)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), 205..<300)
+    XCTAssertEqualSequences(destination, 200..<205)
+
+    let source4 = -200..<0,
+        result4 = destination.copyOntoSuffix(withCollection: source4)
+    XCTAssertEqual(result4.copyStart, destination.startIndex)
+    XCTAssertEqual(result4.sourceTailStart, -195)
+    XCTAssertEqualSequences(destination, (-200)..<(-195))
+    XCTAssertEqualSequences(destination[result4.copyStart...],
+                            source4[..<result4.sourceTailStart])
   }
 
   /// Test a multi-element source shorter than the destination.
@@ -133,6 +221,21 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result2.copyEnd, 3)
     XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
     XCTAssertEqualSequences(destination, "123QRfghijklm")
+    XCTAssertEqualSequences(destination[..<result2.copyEnd],
+                            source2[..<result2.sourceTailStart])
+
+    let source3 = "STUV", result3 = destination.copyOntoSuffix(with: source3)
+    XCTAssertEqual(result3.copyStart, 9)
+    XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
+    XCTAssertEqualSequences(destination, "123QRfghiSTUV")
+
+    let source4 = "45678",
+        result4 = destination.copyOntoSuffix(withCollection: source4)
+    XCTAssertEqual(result4.copyStart, 8)
+    XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
+    XCTAssertEqualSequences(destination, "123QRfgh45678")
+    XCTAssertEqualSequences(destination[result4.copyStart...],
+                            source4[..<result4.sourceTailStart])
   }
 
   /// Test copying over part of the destination.
@@ -155,10 +258,27 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result3.copyEnd, 7)
     XCTAssertEqualSequences(source[result3.sourceTailStart...], "WXYZ")
     XCTAssertEqualSequences(destination, "abcSTUVhijklm")
+    XCTAssertEqualSequences(destination[3..<7][..<result3.copyEnd],
+                            source[..<result3.sourceTailStart])
 
     let source2 = "12", result4 = destination[3..<7].copy(collection: source2)
     XCTAssertEqual(result4.copyEnd, 5)
     XCTAssertEqual(result4.sourceTailStart, source2.endIndex)
     XCTAssertEqualSequences(destination, "abc12UVhijklm")
+    XCTAssertEqualSequences(destination[3..<7][..<result4.copyEnd],
+                            source2[..<result4.sourceTailStart])
+
+    let result5 = destination[3..<7].copyOntoSuffix(with: "34")
+    XCTAssertEqual(result5.copyStart, 5)
+    XCTAssertEqualSequences(IteratorSequence(result5.sourceTail), [])
+    XCTAssertEqualSequences(destination, "abc1234hijklm")
+
+    let source3 = "56",
+        result6 = destination[3..<7].copyOntoSuffix(withCollection: source3)
+    XCTAssertEqual(result6.copyStart, 5)
+    XCTAssertEqual(result6.sourceTailStart, source3.endIndex)
+    XCTAssertEqualSequences(destination, "abc1256hijklm")
+    XCTAssertEqualSequences(destination[3..<7][result6.copyStart...],
+                            source3[..<result6.sourceTailStart])
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import Algorithms
 
-/// Unit tests for the `copy` and `copyOntoSuffix` methods.
+/// Unit tests for the `copy` methods.
 final class CopyTests: XCTestCase {
   /// Test empty source and destination.
   func testBothEmpty() {
@@ -32,12 +32,12 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(empty1[..<result2.copyEnd],
                             empty2[..<result2.sourceTailStart])
 
-    let result3 = empty1.copyOntoSuffix(with: empty2)
+    let result3 = empty1.copy(asSuffix: empty2)
     XCTAssertEqual(result3.copyStart, empty1.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
     XCTAssertEqualSequences(empty1, [])
 
-    let result4 = empty1.copyOntoSuffix(withCollection: empty2)
+    let result4 = empty1.copy(collectionAsSuffix: empty2)
     XCTAssertEqual(result4.copyStart, empty1.endIndex)
     XCTAssertEqual(result4.sourceTailStart, empty2.startIndex)
     XCTAssertEqualSequences(empty1, [])
@@ -70,12 +70,12 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(empty[..<result2.copyEnd],
                             single[..<result2.sourceTailStart])
 
-    let result3 = empty.copyOntoSuffix(with: single)
+    let result3 = empty.copy(asSuffix: single)
     XCTAssertEqual(result3.copyStart, empty.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [1.1])
     XCTAssertEqualSequences(empty, [])
 
-    let result4 = empty.copyOntoSuffix(withCollection: single)
+    let result4 = empty.copy(collectionAsSuffix: single)
     XCTAssertEqual(result4.copyStart, empty.endIndex)
     XCTAssertEqual(result4.sourceTailStart, single.startIndex)
     XCTAssertEqualSequences(empty, [])
@@ -108,12 +108,12 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(single[..<result2.copyEnd],
                             empty[..<result2.sourceTailStart])
 
-    let result3 = single.copyOntoSuffix(with: empty)
+    let result3 = single.copy(asSuffix: empty)
     XCTAssertEqual(result3.copyStart, single.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
     XCTAssertEqualSequences(single, [2.2])
 
-    let result4 = single.copyOntoSuffix(withCollection: empty)
+    let result4 = single.copy(collectionAsSuffix: empty)
     XCTAssertEqual(result4.copyStart, single.endIndex)
     XCTAssertEqual(result4.sourceTailStart, empty.startIndex)
     XCTAssertEqualSequences(single, [2.2])
@@ -148,13 +148,13 @@ final class CopyTests: XCTestCase {
                             source2[..<result2.sourceTailStart])
 
     let source3 = CollectionOfOne(6.6),
-        result3 = destination.copyOntoSuffix(with: source3)
+        result3 = destination.copy(asSuffix: source3)
     XCTAssertEqual(result3.copyStart, destination.startIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
     XCTAssertEqualSequences(destination, [6.6])
 
     let source4 = CollectionOfOne(7.7),
-        result4 = destination.copyOntoSuffix(withCollection: source4)
+        result4 = destination.copy(collectionAsSuffix: source4)
     XCTAssertEqual(result4.copyStart, destination.startIndex)
     XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
     XCTAssertEqualSequences(destination, [7.7])
@@ -188,13 +188,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination[..<result2.copyEnd],
                             source2[..<result2.sourceTailStart])
 
-    let source3 = "KLMNO", result3 = destination.copyOntoSuffix(with: source3)
+    let source3 = "KLMNO", result3 = destination.copy(asSuffix: source3)
     XCTAssertEqual(result3.copyStart, destination.startIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
     XCTAssertEqualSequences(destination, "KLMNO")
 
     let source4 = "67890",
-        result4 = destination.copyOntoSuffix(withCollection: source4)
+        result4 = destination.copy(collectionAsSuffix: source4)
     XCTAssertEqual(result4.copyStart, destination.startIndex)
     XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
     XCTAssertEqualSequences(destination, "67890")
@@ -227,13 +227,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination[..<result2.copyEnd],
                             source2[..<result2.sourceTailStart])
 
-    let source3 = 200..<300, result3 = destination.copyOntoSuffix(with: source3)
+    let source3 = 200..<300, result3 = destination.copy(asSuffix: source3)
     XCTAssertEqual(result3.copyStart, destination.startIndex)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), 205..<300)
     XCTAssertEqualSequences(destination, 200..<205)
 
     let source4 = -200..<0,
-        result4 = destination.copyOntoSuffix(withCollection: source4)
+        result4 = destination.copy(collectionAsSuffix: source4)
     XCTAssertEqual(result4.copyStart, destination.startIndex)
     XCTAssertEqual(result4.sourceTailStart, -195)
     XCTAssertEqualSequences(destination, (-200)..<(-195))
@@ -267,13 +267,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination[..<result2.copyEnd],
                             source2[..<result2.sourceTailStart])
 
-    let source3 = "STUV", result3 = destination.copyOntoSuffix(with: source3)
+    let source3 = "STUV", result3 = destination.copy(asSuffix: source3)
     XCTAssertEqual(result3.copyStart, 9)
     XCTAssertEqualSequences(IteratorSequence(result3.sourceTail), [])
     XCTAssertEqualSequences(destination, "123QRfghiSTUV")
 
     let source4 = "45678",
-        result4 = destination.copyOntoSuffix(withCollection: source4)
+        result4 = destination.copy(collectionAsSuffix: source4)
     XCTAssertEqual(result4.copyStart, 8)
     XCTAssertEqual(result4.sourceTailStart, source4.endIndex)
     XCTAssertEqualSequences(destination, "123QRfgh45678")
@@ -318,13 +318,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination[3..<7][..<result4.copyEnd],
                             source2[..<result4.sourceTailStart])
 
-    let result5 = destination[3..<7].copyOntoSuffix(with: "34")
+    let result5 = destination[3..<7].copy(asSuffix: "34")
     XCTAssertEqual(result5.copyStart, 5)
     XCTAssertEqualSequences(IteratorSequence(result5.sourceTail), [])
     XCTAssertEqualSequences(destination, "abc1234hijklm")
 
     let source3 = "56",
-        result6 = destination[3..<7].copyOntoSuffix(withCollection: source3)
+        result6 = destination[3..<7].copy(collectionAsSuffix: source3)
     XCTAssertEqual(result6.copyStart, 5)
     XCTAssertEqual(result6.sourceTailStart, source3.endIndex)
     XCTAssertEqualSequences(destination, "abc1256hijklm")

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import Algorithms
 
-/// Unit tests for the `copy(from:)` method.
+/// Unit tests for the `copy(from:)` and `copy(collection:)` methods.
 final class CopyTests: XCTestCase {
   /// Test empty source and destination.
   func testBothEmpty() {
@@ -23,6 +23,11 @@ final class CopyTests: XCTestCase {
     let result = empty1.copy(from: empty2)
     XCTAssertEqual(result.copyEnd, empty1.startIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(empty1, [])
+
+    let result2 = empty1.copy(collection: empty2)
+    XCTAssertEqual(result2.copyEnd, empty1.startIndex)
+    XCTAssertEqual(result2.sourceTailStart, empty2.startIndex)
     XCTAssertEqualSequences(empty1, [])
   }
 
@@ -36,6 +41,11 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result.copyEnd, empty.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [1.1])
     XCTAssertEqualSequences(empty, [])
+
+    let result2 = empty.copy(collection: single)
+    XCTAssertEqual(result2.copyEnd, empty.startIndex)
+    XCTAssertEqual(result2.sourceTailStart, single.startIndex)
+    XCTAssertEqualSequences(empty, [])
   }
 
   /// Test empty source and nonempty destination.
@@ -47,6 +57,11 @@ final class CopyTests: XCTestCase {
     let result = single.copy(from: empty)
     XCTAssertEqual(result.copyEnd, single.startIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
+    XCTAssertEqualSequences(single, [2.2])
+
+    let result2 = single.copy(collection: empty)
+    XCTAssertEqual(result2.copyEnd, single.startIndex)
+    XCTAssertEqual(result2.sourceTailStart, empty.startIndex)
     XCTAssertEqualSequences(single, [2.2])
   }
 
@@ -60,6 +75,12 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result.copyEnd, destination.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
     XCTAssertEqualSequences(destination, [4.4])
+
+    let source2 = CollectionOfOne(5.5),
+        result2 = destination.copy(collection: source2)
+    XCTAssertEqual(result2.copyEnd, destination.endIndex)
+    XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
+    XCTAssertEqualSequences(destination, [5.5])
   }
 
   /// Test two equal-length multi-element collections.
@@ -72,6 +93,11 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result.copyEnd, destination.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
     XCTAssertEqualSequences(destination, "fghij")
+
+    let source2 = "12345", result2 = destination.copy(collection: source2)
+    XCTAssertEqual(result2.copyEnd, destination.endIndex)
+    XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
+    XCTAssertEqualSequences(destination, "12345")
   }
 
   /// Test a source longer than a multi-element destination.
@@ -84,6 +110,11 @@ final class CopyTests: XCTestCase {
     XCTAssertEqual(result.copyEnd, destination.endIndex)
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), 15...100)
     XCTAssertEqualSequences(destination, 10..<15)
+
+    let source2 = -50..<0, result2 = destination.copy(collection: source2)
+    XCTAssertEqual(result2.copyEnd, destination.endIndex)
+    XCTAssertEqual(result2.sourceTailStart, -45)
+    XCTAssertEqualSequences(destination, (-50)...(-46))
   }
 
   /// Test a multi-element source shorter than the destination.
@@ -97,6 +128,11 @@ final class CopyTests: XCTestCase {
                                                  offsetBy: source.count))
     XCTAssertEqualSequences(IteratorSequence(result.sourceTail), [])
     XCTAssertEqualSequences(destination, "NOPQRfghijklm")
+
+    let source2 = "123", result2 = destination.copy(collection: source2)
+    XCTAssertEqual(result2.copyEnd, 3)
+    XCTAssertEqual(result2.sourceTailStart, source2.endIndex)
+    XCTAssertEqualSequences(destination, "123QRfghijklm")
   }
 
   /// Test copying over part of the destination.
@@ -113,6 +149,16 @@ final class CopyTests: XCTestCase {
     let result2 = destination[3..<7].copy(from: "12")
     XCTAssertEqual(result2.copyEnd, 5)
     XCTAssertEqualSequences(IteratorSequence(result2.sourceTail), [])
+    XCTAssertEqualSequences(destination, "abc12UVhijklm")
+
+    let result3 = destination[3..<7].copy(collection: source)
+    XCTAssertEqual(result3.copyEnd, 7)
+    XCTAssertEqualSequences(source[result3.sourceTailStart...], "WXYZ")
+    XCTAssertEqualSequences(destination, "abcSTUVhijklm")
+
+    let source2 = "12", result4 = destination[3..<7].copy(collection: source2)
+    XCTAssertEqual(result4.copyEnd, 5)
+    XCTAssertEqual(result4.sourceTailStart, source2.endIndex)
     XCTAssertEqualSequences(destination, "abc12UVhijklm")
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -43,6 +43,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(empty1, [])
     XCTAssertEqualSequences(empty1[result4.copyStart...],
                             empty2[..<result4.sourceTailStart])
+
+    let result5 = empty1.copy(backwards: empty2)
+    XCTAssertEqual(result5.writtenStart, empty1.endIndex)
+    XCTAssertEqual(result5.readStart, empty2.endIndex)
+    XCTAssertEqualSequences(empty1, [])
+    XCTAssertEqualSequences(empty1[result5.writtenStart...],
+                            empty2[result5.readStart...])
   }
 
   /// Test nonempty source and empty destination.
@@ -74,6 +81,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(empty, [])
     XCTAssertEqualSequences(empty[result4.copyStart...],
                             single[..<result4.sourceTailStart])
+
+    let result5 = empty.copy(backwards: single)
+    XCTAssertEqual(result5.writtenStart, empty.endIndex)
+    XCTAssertEqual(result5.readStart, single.endIndex)
+    XCTAssertEqualSequences(empty, [])
+    XCTAssertEqualSequences(empty[result5.writtenStart...],
+                            single[result5.readStart...])
   }
 
   /// Test empty source and nonempty destination.
@@ -105,6 +119,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(single, [2.2])
     XCTAssertEqualSequences(single[result4.copyStart...],
                             empty[..<result4.sourceTailStart])
+
+    let result5 = single.copy(backwards: empty)
+    XCTAssertEqual(result5.writtenStart, single.endIndex)
+    XCTAssertEqual(result5.readStart, empty.endIndex)
+    XCTAssertEqualSequences(single, [2.2])
+    XCTAssertEqualSequences(single[result5.writtenStart...],
+                            empty[result5.readStart...])
   }
 
   /// Test two one-element collections.
@@ -139,6 +160,14 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination, [7.7])
     XCTAssertEqualSequences(destination[result4.copyStart...],
                             source4[..<result4.sourceTailStart])
+
+    let source5 = CollectionOfOne(8.8),
+        result5 = destination.copy(backwards: source5)
+    XCTAssertEqual(result5.writtenStart, destination.startIndex)
+    XCTAssertEqual(result5.readStart, source5.startIndex)
+    XCTAssertEqualSequences(destination, [8.8])
+    XCTAssertEqualSequences(destination[result5.writtenStart...],
+                            source5[result5.readStart...])
   }
 
   /// Test two equal-length multi-element collections.
@@ -171,6 +200,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination, "67890")
     XCTAssertEqualSequences(destination[result4.copyStart...],
                             source4[..<result4.sourceTailStart])
+
+    let source5 = "pqrst", result5 = destination.copy(backwards: source5)
+    XCTAssertEqual(result5.writtenStart, destination.startIndex)
+    XCTAssertEqual(result5.readStart, source5.startIndex)
+    XCTAssertEqualSequences(destination, "pqrst")
+    XCTAssertEqualSequences(destination[result5.writtenStart...],
+                            source5[result5.readStart...])
   }
 
   /// Test a source longer than a multi-element destination.
@@ -203,6 +239,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination, (-200)..<(-195))
     XCTAssertEqualSequences(destination[result4.copyStart...],
                             source4[..<result4.sourceTailStart])
+
+    let source5 = 400..<500, result5 = destination.copy(backwards: source5)
+    XCTAssertEqual(result5.writtenStart, destination.startIndex)
+    XCTAssertEqual(result5.readStart, 495)
+    XCTAssertEqualSequences(destination, 495..<500)
+    XCTAssertEqualSequences(destination[result5.writtenStart...],
+                            source5[result5.readStart...])
   }
 
   /// Test a multi-element source shorter than the destination.
@@ -236,6 +279,13 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination, "123QRfgh45678")
     XCTAssertEqualSequences(destination[result4.copyStart...],
                             source4[..<result4.sourceTailStart])
+
+    let source5 = "wxyz", result5 = destination.copy(backwards: source5)
+    XCTAssertEqual(result5.writtenStart, 9)
+    XCTAssertEqual(result5.readStart, source5.startIndex)
+    XCTAssertEqualSequences(destination, "123QRfgh4wxyz")
+    XCTAssertEqualSequences(destination[result5.writtenStart...],
+                            source5[result5.readStart...])
   }
 
   /// Test copying over part of the destination.
@@ -280,5 +330,12 @@ final class CopyTests: XCTestCase {
     XCTAssertEqualSequences(destination, "abc1256hijklm")
     XCTAssertEqualSequences(destination[3..<7][result6.copyStart...],
                             source3[..<result6.sourceTailStart])
+
+    let source4 = "NOP", result7 = destination[3..<7].copy(backwards: source4)
+    XCTAssertEqual(result7.writtenStart, 4)
+    XCTAssertEqual(result7.readStart, source4.startIndex)
+    XCTAssertEqualSequences(destination, "abc1NOPhijklm")
+    XCTAssertEqualSequences(destination[3..<7][result7.writtenStart...],
+                            source4[result7.readStart...])
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CopyTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CopyTests.swift
@@ -174,7 +174,7 @@ final class CopyTests: XCTestCase {
   }
 
   /// Test a source longer than a multi-element destination.
-  func testLongerDestination() {
+  func testLongerSource() {
     var destination = Array(1...5)
     let source = 10...100
     XCTAssertEqualSequences(destination, 1...5)
@@ -206,7 +206,7 @@ final class CopyTests: XCTestCase {
   }
 
   /// Test a multi-element source shorter than the destination.
-  func testShorterDestination() {
+  func testShorterSource() {
     var destination = Array("abcdefghijklm")
     let source = "NOPQR"
     XCTAssertEqualSequences(destination, "abcdefghijklm")


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description

This change adds methods that introduces new elements to a collection via overwriting existing elements (instead of inserting more space).

### Detailed Design

The are methods that copy across subsequences of the same collection, both in the forward and backward directions.  The main versions use a separate object as the source.  There are combinations for `Sequence` vs. `Collection` source, and copying over the prefix vs. suffix.  There is another main version that copies suffix to suffix.

```swift
extension MutableCollection {
    /// Copies the prefix of the given sequence on top of the prefix of this collection.
    public mutating func copy<S>(from source: S) -> (copyEnd: Index, sourceTail: S.Iterator) where S : Sequence, Self.Element == S.Element

    /// Copies the prefix of the given collection on top of the prefix of this collection.
    public mutating func copy<C>(collection: C) -> (copyEnd: Index, sourceTailStart: C.Index) where C : Collection, Self.Element == C.Element

    /// Copies, in forward traversal, the prefix of a subsequence on top of the prefix of another, using the given bounds to demarcate the subsequences.
    public mutating func copy<R, S>(forwardsFrom source: R, to destination: S) -> (sourceRead: Range<Index>, destinationWritten: Range<Index>) where R : RangeExpression, S : RangeExpression, Self.Index == R.Bound, R.Bound == S.Bound
}

extension MutableCollection where Self : BidirectionalCollection {
    /// Copies the prefix of the given sequence on top of the suffix of this collection.
    public mutating func copy<S>(asSuffix source: S) -> (copyStart: Index, sourceTail: S.Iterator) where S : Sequence, Self.Element == S.Element

    /// Copies the prefix of the given collection on top of the suffix of this collection.
    public mutating func copy<C>(collectionAsSuffix source: C) -> (copyStart: Index, sourceTailStart: C.Index) where C : Collection, Self.Element == C.Element

    /// Copies the suffix of the given collection on top of the suffix of this collection.
    public mutating func copy<C>(backwards source: C) -> (writtenStart: Index, readStart: C.Index) where C : BidirectionalCollection, Self.Element == C.Element

    /// Copies, in reverse traversal, the suffix of a subsequence on top of the suffix of another, using the given bounds to demarcate the subsequences.
    public mutating func copy<R, S>(backwardsFrom source: R, to destination: S) -> (sourceRead: Range<Index>, destinationWritten: Range<Index>) where R : RangeExpression, S : RangeExpression, Self.Index == R.Bound, R.Bound == S.Bound
}
```

### Documentation Plan

The methods have documentation comments.  There is also a guide file.

### Test Plan

There is a XC Test file for these methods.

### Source Impact

The change adds API.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
