### PR TITLE
[Chunked] Add `chunks(of:)` variant that divides a collection in chunks of a given size

### DIFF
--- a/Guides/Chunked.md
+++ b/Guides/Chunked.md
@@ -4,7 +4,10 @@
  [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/ChunkedTests.swift)]
 
 Break a collection into subsequences where consecutive elements pass a binary
-predicate, or where all elements in each chunk project to the same value.
+predicate, or where all elements in each chunk project to the same value. 
+
+Also, includes a `chunks(ofCount:)` that breaks a collection into subsequences 
+of a given `count`.
 
 There are two variations of the `chunked` method: `chunked(by:)` and
 `chunked(on:)`. `chunked(by:)` uses a binary predicate to test consecutive
@@ -26,16 +29,31 @@ let chunks = names.chunked(on: \.first!)
 // [["David"], ["Kyle", "Karoy"], ["Nate"]] 
 ```
 
-These methods are related to the [existing SE proposal][proposal] for chunking a
-collection into subsequences of a particular size, potentially named something
-like `chunked(length:)`. Unlike the `split` family of methods, the entire
-collection is included in the chunked result — joining the resulting chunks
-recreates the original collection.
+The `chunks(ofCount:)` takes a `count` parameter (required to be > 0) and separates 
+the collection into `n` chunks of this given count. If the `count` parameter is 
+evenly divided by the count of the base `Collection` all the chunks will have 
+the count equals to the parameter. Otherwise, the last chunk will contain the 
+remaining elements.
+ 
+```swift
+let names = ["David", "Kyle", "Karoy", "Nate"]
+let evenly = names.chunks(ofCount: 2)
+// equivalent to [["David", "Kyle"], ["Karoy", "Nate"]] 
+
+let remaining = names.chunks(ofCount: 3)
+// equivalent to [["David", "Kyle", "Karoy"], ["Nate"]]
+```
+
+The `chunks(ofCount:)` is the method of the [existing SE proposal][proposal]. 
+Unlike the `split` family of methods, the entire collection is included in the
+chunked result — joining the resulting chunks recreates the original collection. 
 
 ```swift
 c.elementsEqual(c.chunked(...).joined())
 // true
 ```
+
+Check the [proposal][proposal] detailed design section for more info. 
 
 [proposal]: https://github.com/apple/swift-evolution/pull/935
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Other useful operations
 
-- [`chunked(by:)`, `chunked(on:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes.
+- [`chunked(by:)`, `chunked(on:)`, `chunks(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes or chunks of a given count.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`trimming(where:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end. 
 

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -368,12 +368,12 @@ where Base: RandomAccessCollection {
     guard limit != i else { return nil }
     
     if offset > 0 {
-      guard limit <= i || distance(from: i, to: limit) >= offset else {
+      guard limit < i || distance(from: i, to: limit) >= offset else {
         return nil
       }
       return offsetForward(i, offsetBy: offset)
     } else {
-      guard limit >= i || distance(from: i, to: limit) <= offset else {
+      guard limit > i || distance(from: i, to: limit) <= offset else {
         return nil
       }
       return offsetBackward(i, offsetBy: offset)
@@ -397,14 +397,14 @@ where Base: RandomAccessCollection {
   }
   
   @usableFromInline
-  internal func offsetBackward(_ i: Index, offsetBy n: Int) -> Index {
+  internal func offsetBackward(_ i: Index, offsetBy distance: Int) -> Index {
     var idx = i
-    var distance = n
+    var distance = distance
     // If we know that the last chunk is the only one that can possible
     // have a variadic count. So in order to simplify and avoid another
     // calculation of offsets(that is already done at `index(before:)`)
     // we just move one position already so the index can be calculated
-    // assuming all chunks have the same size.
+    // since all remaining chunks have the same size.
     if i.baseRange.lowerBound == base.endIndex {
       formIndex(before: &idx)
       distance += 1
@@ -420,7 +420,8 @@ where Base: RandomAccessCollection {
   }
   
   // Helper to compute index(offsetBy:) index.
-  internal func makeOffsetIndex(
+  @inline(__always)
+  private func makeOffsetIndex(
     from i: Index, baseBound: Base.Index, distance: Int
   ) -> Index {
     let baseStartIdx = base.index(

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -76,4 +76,67 @@ final class ChunkedTests: XCTestCase {
     XCTAssertLazySequence(fruits.lazy.chunked(by: { $0.first == $1.first }))
     XCTAssertLazySequence(fruits.lazy.chunked(on: { $0.first }))
   }
+  
+  
+  //===----------------------------------------------------------------------===//
+  // Tests for `chunks(ofCount:)`
+  //===----------------------------------------------------------------------===//
+  func testChunksOfCount() {
+    XCTAssertEqualSequences([Int]().chunks(ofCount: 1), [])
+    XCTAssertEqualSequences([Int]().chunks(ofCount: 5), [])
+
+    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    XCTAssertEqualSequences(collection.chunks(ofCount: 1),
+                            [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 3),
+                            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 5),
+                            [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 11),
+                            [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+  }
+  
+  func testChunksOfCountBidirectional() {
+    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    XCTAssertEqualSequences(collection.chunks(ofCount: 1).reversed(),
+                            [[10], [9], [8], [7], [6], [5], [4], [3], [2], [1]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 3).reversed(),
+                            [[10], [7, 8, 9], [4, 5, 6], [1, 2, 3]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 5).reversed(),
+                            [[6, 7, 8, 9, 10], [1, 2, 3, 4, 5]])
+    XCTAssertEqualSequences(collection.chunks(ofCount: 11).reversed(),
+                            [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+  }
+  
+  func testChunksOfCountCount() {
+    XCTAssertEqual([Int]().chunks(ofCount: 1).count, 0)
+    XCTAssertEqual([Int]().chunks(ofCount: 5).count, 0)
+
+    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    XCTAssertEqual(collection.chunks(ofCount: 1).count, 10)
+    XCTAssertEqual(collection.chunks(ofCount: 3).count, 4)
+    XCTAssertEqual(collection.chunks(ofCount: 5).count, 2)
+    XCTAssertEqual(collection.chunks(ofCount: 11).count, 1)
+  }
+
+  func testEmptyChunksTraversal() {
+    let emptyChunks = [Int]().chunks(ofCount: 1)
+    
+    validateIndexTraversals(emptyChunks)
+  }
+  
+  func testChunksOfCountTraversal() {
+    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    let chunks = collection.chunks(ofCount: 2)
+  
+    validateIndexTraversals(chunks)
+  }
+  
+  func testChunksOfCountWithRemainderTraversal() {
+    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    let chunks = collection.chunks(ofCount: 3)
+  
+    validateIndexTraversals(chunks)
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -138,23 +138,11 @@ final class ChunkedTests: XCTestCase {
   }
   
   func testChunksOfCountTraversal() {
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    let chunks = collection.chunks(ofCount: 2)
-  
-    validateIndexTraversals(chunks)
-  }
-  
-  func testChunksOfCountWithSingleRemainderTraversal() {
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    let chunks = collection.chunks(ofCount: 3)
-  
-    validateIndexTraversals(chunks)
-  }
-  
-  func testChunksOfCountWithRemainder() {
-    let collection2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    let chunks = collection2.chunks(ofCount: 3)
-    
-    validateIndexTraversals(chunks)
+    for i in 1..<10 {
+      let collection = (1...50).map { $0 }
+      let chunks = collection.chunks(ofCount: i)
+      
+      validateIndexTraversals(chunks)
+    }
   }
 }

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -113,11 +113,14 @@ final class ChunkedTests: XCTestCase {
     XCTAssertEqual([Int]().chunks(ofCount: 1).count, 0)
     XCTAssertEqual([Int]().chunks(ofCount: 5).count, 0)
 
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    XCTAssertEqual(collection.chunks(ofCount: 1).count, 10)
-    XCTAssertEqual(collection.chunks(ofCount: 3).count, 4)
-    XCTAssertEqual(collection.chunks(ofCount: 5).count, 2)
-    XCTAssertEqual(collection.chunks(ofCount: 11).count, 1)
+    let collection1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    XCTAssertEqual(collection1.chunks(ofCount: 1).count, 10)
+    XCTAssertEqual(collection1.chunks(ofCount: 3).count, 4)
+    XCTAssertEqual(collection1.chunks(ofCount: 5).count, 2)
+    XCTAssertEqual(collection1.chunks(ofCount: 11).count, 1)
+    
+    let collection2 = (1...50).map { $0 }
+    XCTAssertEqual(collection2.chunks(ofCount: 9).count, 6)
   }
 
   func testEmptyChunksTraversal() {

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -85,28 +85,36 @@ final class ChunkedTests: XCTestCase {
     XCTAssertEqualSequences([Int]().chunks(ofCount: 1), [])
     XCTAssertEqualSequences([Int]().chunks(ofCount: 5), [])
 
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    XCTAssertEqualSequences(collection.chunks(ofCount: 1),
+    let collection1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 1),
                             [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 3),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 3),
                             [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 5),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 5),
                             [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 11),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 11),
                             [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+    
+    let collection2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    XCTAssertEqualSequences(collection2.chunks(ofCount: 3),
+                            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11]])
   }
   
   func testChunksOfCountBidirectional() {
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    let collection1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-    XCTAssertEqualSequences(collection.chunks(ofCount: 1).reversed(),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 1).reversed(),
                             [[10], [9], [8], [7], [6], [5], [4], [3], [2], [1]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 3).reversed(),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 3).reversed(),
                             [[10], [7, 8, 9], [4, 5, 6], [1, 2, 3]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 5).reversed(),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 5).reversed(),
                             [[6, 7, 8, 9, 10], [1, 2, 3, 4, 5]])
-    XCTAssertEqualSequences(collection.chunks(ofCount: 11).reversed(),
+    XCTAssertEqualSequences(collection1.chunks(ofCount: 11).reversed(),
                             [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+    
+    let collection2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    XCTAssertEqualSequences(collection2.chunks(ofCount: 3).reversed(),
+                            [[10, 11], [7, 8, 9], [4, 5, 6], [1, 2, 3]])
   }
   
   func testChunksOfCountCount() {
@@ -123,7 +131,7 @@ final class ChunkedTests: XCTestCase {
     XCTAssertEqual(collection2.chunks(ofCount: 9).count, 6)
   }
 
-  func testEmptyChunksTraversal() {
+  func testEmptyChunksOfCountTraversal() {
     let emptyChunks = [Int]().chunks(ofCount: 1)
     
     validateIndexTraversals(emptyChunks)
@@ -136,10 +144,17 @@ final class ChunkedTests: XCTestCase {
     validateIndexTraversals(chunks)
   }
   
-  func testChunksOfCountWithRemainderTraversal() {
+  func testChunksOfCountWithSingleRemainderTraversal() {
     let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     let chunks = collection.chunks(ofCount: 3)
   
+    validateIndexTraversals(chunks)
+  }
+  
+  func testChunksOfCountWithRemainder() {
+    let collection2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    let chunks = collection2.chunks(ofCount: 3)
+    
     validateIndexTraversals(chunks)
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This just adds the `chunks(of:)` to chunk a collection into subsequences of a given size. 
As suggested by @bjhomer [here](https://forums.swift.org/t/pull-in-chunks-ofsize-from-separate-proposal/42575) this is just moving a long time opened [evolution proposal](https://forums.swift.org/t/pull-in-chunks-ofsize-from-separate-proposal/42575) to this package. So let me know what you think =] 

cc @natecook1000 @kylemacomber 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

