### PR TITLE
Add `lastIndex` variants returning `Range<Index>?`

### DIFF
--- a/Guides/LastIndex.md
+++ b/Guides/LastIndex.md
@@ -1,0 +1,25 @@
+# LastIndex
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/LastIndex.swift) |
+  [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/LastIndexTests.swift)]
+
+The `lastIndexAsRange(where:)` and `lastIndexAsRange(of:)` methods return an optional range,
+containing the last index of a matching element in the bidirectional collection.
+
+The range's upper bound can then be used to form another half-open range.
+
+```swift
+let hexDigits: [Character] = Array("0123456789ABCDEF")
+
+hexDigits.lastIndexAsRange(where: \.isLetter)  //-> 0xF..<0x10
+hexDigits.lastIndexAsRange(where: \.isNumber)  //-> 0x9..<0xA
+hexDigits.lastIndexAsRange(where: \.isSymbol)  //-> nil
+hexDigits.lastIndexAsRange(of: "F")            //-> 0xF..<0x10
+hexDigits.lastIndexAsRange(of: "9")            //-> 0x9..<0xA
+hexDigits.lastIndexAsRange(of: "$")            //-> nil
+
+if let range = hexDigits.lastIndexAsRange(where: \.isNumber) {
+  let digits = hexDigits[..<range.upperBound]
+  digits.allSatisfy(\.isNumber)  //-> true
+}
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 - [`trimming(where:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end. 
 - [`slidingWindows(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/SlidingWindows.md): Breaks a collection into overlapping contiguous window subsequences where elements are slices from the original collection.
 - [`striding(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Stride.md): Returns every nth element of a collection.
+- [`lastIndexAsRange(where:)`, `lastIndexAsRange(of:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/LastIndex.md): Returns an optional range, containing the last index of a matching element in the bidirectional collection.
 
 ## Adding Swift Algorithms as a Dependency
 

--- a/Sources/Algorithms/LastIndex.swift
+++ b/Sources/Algorithms/LastIndex.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// lastIndexAsRange(where:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+
+  /// Returns an optional range, containing the last index where an element
+  /// matches the given predicate; or returns `nil` if no elements match.
+  ///
+  /// This is equivalent to calling `lastIndex(where:)` for the lower bound,
+  /// but it avoids an extra call to `index(after:)` for the upper bound.
+  ///
+  /// - Parameter predicate: A closure that returns a Boolean value,
+  ///   indicating whether a given element represents a match.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func lastIndexAsRange(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Range<Index>? {
+    var upperBound = endIndex
+    while upperBound != startIndex {
+      let lowerBound = index(before: upperBound)
+      if try predicate(self[lowerBound]) {
+        return lowerBound..<upperBound
+      }
+      upperBound = lowerBound
+    }
+    return nil
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// lastIndexAsRange(of:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection where Element: Equatable {
+
+  /// Returns an optional range, containing the last index of the given element;
+  /// or returns `nil` if the element is not found in the collection.
+  ///
+  /// This is equivalent to calling `lastIndex(of:)` for the lower bound,
+  /// but it avoids an extra call to `index(after:)` for the upper bound.
+  ///
+  /// - Parameter element: An element to search for in the collection.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func lastIndexAsRange(
+    of element: Element
+  ) -> Range<Index>? {
+    lastIndexAsRange(where: { $0 == element })
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/LastIndexTests.swift
+++ b/Tests/SwiftAlgorithmsTests/LastIndexTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class LastIndexTests: XCTestCase {
+
+  func testEmpty() {
+    let empty = EmptyCollection<Bool>()
+    XCTAssertNil(empty.lastIndexAsRange(where: { _ in true }))
+    XCTAssertNil(empty.lastIndexAsRange(of: true))
+  }
+
+  func testArray() {
+    let hexDigits: [Character] = Array("0123456789ABCDEF")
+    XCTAssertEqual(0xF..<0x10, hexDigits.lastIndexAsRange(where: \.isLetter))
+    XCTAssertEqual(0x9..<0xA,  hexDigits.lastIndexAsRange(where: \.isNumber))
+    XCTAssertEqual(0xF..<0x10, hexDigits.lastIndexAsRange(of: "F"))
+    XCTAssertEqual(0xE..<0xF,  hexDigits.lastIndexAsRange(of: "E"))
+    XCTAssertEqual(0x9..<0xA,  hexDigits.lastIndexAsRange(of: "9"))
+    XCTAssertEqual(0x1..<0x2,  hexDigits.lastIndexAsRange(of: "1"))
+    XCTAssertEqual(0x0..<0x1,  hexDigits.lastIndexAsRange(of: "0"))
+    XCTAssertNil(hexDigits.lastIndexAsRange(where: \.isSymbol))
+    XCTAssertNil(hexDigits.lastIndexAsRange(of: "$"))
+  }
+}


### PR DESCRIPTION
### Description

Closes #23

### Detailed Design

```swift
extension BidirectionalCollection {
  public func lastIndexAsRange(
    where predicate: (Element) throws -> Bool
  ) rethrows -> Range<Index>?
}

extension BidirectionalCollection where Element: Equatable {
  public func lastIndexAsRange(
    of element: Element
  ) -> Range<Index>?
}
```

### Documentation Plan

- README.md (added link to guide).
- Guides/LastIndex.md (added example code).
- Sources/Algorithms/LastIndex.swift (added documentation comments).

### Test Plan

- Tests/SwiftAlgorithmsTests/LastIndexTests.swift

### Source Impact

None (new API only).

### Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
