### PR TITLE
All permutations

### DIFF
--- a/Guides/Permutations.md
+++ b/Guides/Permutations.md
@@ -60,6 +60,31 @@ for perm in numbers2.permutations() {
 // [10, 10, 20]
 ```
 
+Given a range, the `permutations(ofCount:)` method returns a sequence of all the different permutations of the given sizes of a collection’s elements in increasing order of size.
+
+```swift
+let numbers = [10, 20, 30]
+for perm in numbers.permutations(ofCount: 0...) {
+    print(perm)
+}
+// []
+// [10]
+// [20]
+// [30]
+// [10, 20]
+// [10, 30]
+// [20, 10]
+// [20, 30]
+// [30, 10]
+// [30, 20]
+// [10, 20, 30]
+// [10, 30, 20]
+// [20, 10, 30]
+// [20, 30, 10]
+// [30, 10, 20]
+// [30, 20, 10]
+```
+
 ## Detailed Design
 
 The `permutations(ofCount:)` method is declared as a `Collection` extension,

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -149,11 +149,8 @@ extension Permutations: Sequence {
       /// Advances `kRange` by incrementing its `lowerBound` until the range is
       /// empty, when iteration is finished.
       func advanceKRange() {
-        if kRange.lowerBound < kRange.upperBound {
-          let advancedLowerBound = kRange.lowerBound + 1
-          kRange = advancedLowerBound ..< kRange.upperBound
-          indexes = Array(base.indices)
-        }
+        kRange.removeFirst()
+        indexes = Array(base.indices)
       }
       
       let countToChoose = self.kRange.lowerBound

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -301,7 +301,9 @@ extension Collection {
   ///   If `k` is `nil`, the resulting sequence represents permutations of this
   ///   entire collection.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
+  /// is the number of elements in the base collection, since `Permutations`
+  /// accesses the `count` of the base collection.
   @inlinable
   public func permutations(ofCount k: Int? = nil) -> Permutations<Self> {
     precondition(

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -298,8 +298,8 @@ extension Collection {
   /// sequence, the resulting sequence has no elements.
   ///
   /// - Parameter k: The number of elements to include in each permutation.
-  ///   If `count` is `nil`, the resulting sequence represents permutations
-  ///   of this entire collection.
+  ///   If `k` is `nil`, the resulting sequence represents permutations of this
+  ///   entire collection.
   ///
   /// - Complexity: O(1)
   @inlinable

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -164,8 +164,8 @@ where Self: BidirectionalCollection, Element: Comparable
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @usableFromInline
   internal mutating func nextPermutation() -> Bool {
-    // ensure we have > 1 element in the collection
-    if isEmpty { return false }
+    // Ensure we have > 1 element in the collection.
+    guard !isEmpty else { return false }
     var i = index(before: endIndex)
     if i == startIndex { return false }
     

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -30,12 +30,13 @@ public struct Permutations<Base: Collection> {
       : 0
   }
 }
- 
+
 extension Permutations: Sequence {
   /// The iterator for a `Permutations` instance.
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var base: Base
+    
     @usableFromInline
     internal var indexes: [Base.Index]
     @usableFromInline
@@ -83,28 +84,28 @@ extension Permutations: Sequence {
     @usableFromInline
     internal mutating func nextState() -> Bool {
       let edge = countToChoose - 1
-
+      
       // Find first index greater than the one at `edge`.
       if let i = indexes[countToChoose...].firstIndex(where: { indexes[edge] < $0 }) {
         indexes.swapAt(edge, i)
       } else {
-        indexes.reverse(subrange: countToChoose..<indexes.endIndex)
-
+        indexes.reverse(subrange: countToChoose ..< indexes.endIndex)
+        
         // Find last increasing pair below `edge`.
         // TODO: This could be indexes[..<edge].adjacentPairs().lastIndex(where: ...)
         var lastAscent = edge - 1
         while (lastAscent >= 0 && indexes[lastAscent] >= indexes[lastAscent + 1]) {
           lastAscent -= 1
         }
-        if (lastAscent < 0) {
+        if lastAscent < 0 {
           return false
         }
-
+        
         // Find rightmost index less than that at `lastAscent`.
         if let i = indexes[lastAscent...].lastIndex(where: { indexes[lastAscent] < $0 }) {
           indexes.swapAt(lastAscent, i)
         }
-        indexes.reverse(subrange: (lastAscent + 1)..<indexes.endIndex)
+        indexes.reverse(subrange: (lastAscent + 1) ..< indexes.endIndex)
       }
       
       return true
@@ -147,7 +148,7 @@ extension Permutations: LazySequenceProtocol where Base: LazySequenceProtocol {}
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection
-  where Self: BidirectionalCollection, Element: Comparable
+where Self: BidirectionalCollection, Element: Comparable
 {
   /// Permutes this collection's elements through all the lexical orderings.
   ///
@@ -178,7 +179,7 @@ extension MutableCollection
           formIndex(before: &j)
         }
         swapAt(i, j)
-        self.reverse(subrange: ip1..<endIndex)
+        self.reverse(subrange: ip1 ..< endIndex)
         return true
       }
       

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -249,6 +249,55 @@ where Self: BidirectionalCollection, Element: Comparable
 //===----------------------------------------------------------------------===//
 
 extension Collection {
+  /// Returns a collection of the permutations of this collection with lengths
+  /// in the specified range.
+  ///
+  /// This example prints the different permutations of one to two elements from
+  /// an array of three names:
+  ///
+  ///     let names = ["Alex", "Celeste", "Davide"]
+  ///     for perm in names.permutations(ofCount: 1...2) {
+  ///         print(perm.joined(separator: ", "))
+  ///     }
+  ///     // Alex
+  ///     // Celeste
+  ///     // Davide
+  ///     // Alex, Celeste
+  ///     // Alex, Davide
+  ///     // Celeste, Alex
+  ///     // Celeste, Davide
+  ///     // Davide, Alex
+  ///     // Davide, Celeste
+  ///
+  /// This example prints _all_ the permutations (including an empty array) from
+  /// the an array of numbers:
+  ///
+  ///     let numbers = [10, 20, 30]
+  ///    for perm in numbers.permutations(ofCount: 0...) {
+  ///        print(perm)
+  ///    }
+  ///    // []
+  ///    // [10]
+  ///    // [20]
+  ///    // [30]
+  ///    // [10, 20]
+  ///    // [10, 30]
+  ///    // [20, 10]
+  ///    // [20, 30]
+  ///    // [30, 10]
+  ///    // [30, 20]
+  ///    // [10, 20, 30]
+  ///    // [10, 30, 20]
+  ///    // [20, 10, 30]
+  ///    // [20, 30, 10]
+  ///    // [30, 10, 20]
+  ///    // [30, 20, 10]
+  ///
+  /// - Parameter kRange: The number of elements to include in each permutation.
+  ///
+  /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
+  /// is the number of elements in the base collection, since `Permutations`
+  /// accesses the `count` of the base collection.
   @inlinable
   public func permutations<R: RangeExpression>(
     ofCount kRange: R

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -144,7 +144,7 @@ extension Permutations: Sequence {
 extension Permutations: LazySequenceProtocol where Base: LazySequenceProtocol {}
 
 //===----------------------------------------------------------------------===//
-// nextPermutation(by:)
+// nextPermutation()
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -11,7 +11,7 @@
 
 /// A sequence of all the permutations of a collection's elements.
 public struct Permutations<Base: Collection> {
-  /// The base collection.
+  /// The base collection to iterate over for permutations.
   public let base: Base
   
   internal let baseCount: Int

--- a/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
@@ -26,27 +26,58 @@ final class PermutationsTests: XCTestCase {
       XCTAssertTrue(p.allSatisfy { $0.count == count })
       XCTAssertTrue(p.isSorted(by: { $0.lexicographicallyPrecedes($1) }))
     }
-
+    
+    func ts<R: RangeExpression>(count: R) where R.Bound == Int {
+      let p = count.relative(to: 0 ..< .max)
+        .clamped(to: 0 ..< c.count + 1)
+        .flatMap {
+          c.permutations(ofCount: $0)
+        }
+      
+      let p2 = c.permutations(ofCount: count)
+      
+      XCTAssertEqual(p.count, p2.count)
+      XCTAssertEqualSequences(p, Array(p2))
+    }
+    
+    t(count: 0)
     t(count: 1)
     t(count: 2)
     t(count: 3)
     t(count: 4)
     t(count: 5)
     t(count: nil)
+    
+    ts(count: 0...0)
+    ts(count: 1...1)
+    ts(count: 0...1)
+    ts(count: 0...2)
+    ts(count: 0...3)
+    ts(count: 1...3)
+    ts(count: 2...3)
+    ts(count: 0...)
+    ts(count: ...5)
+    ts(count: ...4)
+    ts(count: ...6)
   }
   
   func testEmpty() {
     // `k == 0` results in one zero-length permutation
     XCTAssertEqual(1, "".permutations().count)
     XCTAssertEqual(1, "ABCD".permutations(ofCount: 0).count)
+    XCTAssertEqual(1, "ABCD".permutations(ofCount: 0...0).count)
     XCTAssertEqual(Array("".permutations()), [[]])
     XCTAssertEqual(Array("".permutations(ofCount: 0)), [[]])
     XCTAssertEqual(Array("ABCD".permutations(ofCount: 0)), [[]])
+    XCTAssertEqual(Array("ABCD".permutations(ofCount: 0...0)), [[]])
     
     // `k` greater than element count results in zero permutations
     XCTAssertEqual(0, "".permutations(ofCount: 5).count)
     XCTAssertEqual(Array("".permutations(ofCount: 5)), [])
     XCTAssertEqual(Array("ABCD".permutations(ofCount: 5)), [])
+    XCTAssertEqual(Array("ABCD".permutations(ofCount: 5..<6)), [])
+    XCTAssertEqual(Array("ABCD".permutations(ofCount: 5..<7)), [])
+    XCTAssertEqual(Array("ABCD".permutations(ofCount: 5...)), [])
   }
   
   func testNextPermutation() {
@@ -64,7 +95,7 @@ final class PermutationsTests: XCTestCase {
     XCTAssertEqual([1, 2, 3, 4, 7, 6, 5], numbers)
     _ = numbers.nextPermutation()
     XCTAssertEqual([1, 2, 3, 5, 4, 6, 7], numbers)
-
+    
     // Fast-forward to end of permutations.
     while numbers.nextPermutation() {}
     XCTAssertEqual([1, 2, 3, 4, 5, 6, 7], numbers)

--- a/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PermutationsTests.swift
@@ -104,4 +104,101 @@ final class PermutationsTests: XCTestCase {
   func testPermutationsLazy() {
     XCTAssertLazySequence("ABCD".lazy.permutations(ofCount: 2))
   }
+  
+  func testDocumentationExample1() {
+    // From Guides/Permutations.md
+    let numbers = [10, 20, 30]
+    let permutations = numbers.permutations()
+    XCTAssertEqualSequences(permutations, [
+      [10, 20, 30],
+      [10, 30, 20],
+      [20, 10, 30],
+      [20, 30, 10],
+      [30, 10, 20],
+      [30, 20, 10],
+    ])
+  }
+  
+  func testDocumentationExample2() {
+    // From Guides/Permutations.md
+    let numbers = [10, 20, 30]
+    let permutations = numbers.permutations(ofCount: 2)
+    XCTAssertEqualSequences(permutations, [
+      [10, 20],
+      [10, 30],
+      [20, 10],
+      [20, 30],
+      [30, 10],
+      [30, 20],
+    ])
+  }
+  
+  func testDocumentationExample3() {
+    // From Guides/Permutations.md
+    let numbers2 = [20, 10, 10]
+    let permutations = numbers2.permutations()
+    XCTAssertEqualSequences(permutations, [
+      [20, 10, 10],
+      [20, 10, 10],
+      [10, 20, 10],
+      [10, 10, 20],
+      [10, 20, 10],
+      [10, 10, 20],
+    ])
+  }
+  
+  func testDocumentationExample4() {
+    // From Guides/Permutations.md
+    let numbers = [10, 20, 30]
+    let permutations = numbers.permutations(ofCount: 0...)
+    XCTAssertEqualSequences(permutations, [
+      [],
+      [10],
+      [20],
+      [30],
+      [10, 20],
+      [10, 30],
+      [20, 10],
+      [20, 30],
+      [30, 10],
+      [30, 20],
+      [10, 20, 30],
+      [10, 30, 20],
+      [20, 10, 30],
+      [20, 30, 10],
+      [30, 10, 20],
+      [30, 20, 10],
+    ])
+  }
+  
+  func testDocumentationExample5() {
+    // From Permutations.swift
+    let names = ["Alex", "Celeste", "Davide"]
+    let permutations = names.permutations(ofCount: 2)
+    XCTAssertEqualSequences(permutations, [
+      ["Alex", "Celeste"],
+      ["Alex", "Davide"],
+      ["Celeste", "Alex"],
+      ["Celeste", "Davide"],
+      ["Davide", "Alex"],
+      ["Davide", "Celeste"],
+    ])
+  }
+  
+  func testDocumentationExample6() {
+    // From Permutations.swift
+    let names = ["Alex", "Celeste", "Davide"]
+    let permutations = names.permutations(ofCount: 1...2)
+    XCTAssertEqualSequences(permutations, [
+      ["Alex"],
+      ["Celeste"],
+      ["Davide"],
+      ["Alex", "Celeste"],
+      ["Alex", "Davide"],
+      ["Celeste", "Alex"],
+      ["Celeste", "Davide"],
+      ["Davide", "Alex"],
+      ["Davide", "Celeste"],
+    ])
+  }
 }


### PR DESCRIPTION
### Description
This addition adds the ability to easily get permutations of a range of sizes, instead of the previous behavior of a single, fixed size, `k`, like https://github.com/apple/swift-algorithms/pull/51 did for `Combinations`.

### Detailed Design
The `permutations(ofCount:)` function that takes a `RangeExpression` is added in an extension of `Collection`.

```swift
extension Collection {
  public func permutations<R: RangeExpression>(
    ofCount kRange: R
  ) -> Permutations<Self> where R.Bound == Int {
    return Permutations(self, kRange: kRange)
  }
}
```

If the upper bound of the range exceeds the length of the collection, no such permutations of those sizes will be returned, effectively clamping the range to `0...n` where `n` is the length of the collection.

### Naming
The name `permutations(ofCount:)` is the same as the original, but reflects the ability to provide multiple counts. This is [the same pattern used for `Combinations`](https://github.com/apple/swift-algorithms/pull/51).

### Documentation Plan
The documentation in `Guides/Permutations.md` has been updated to reflect the new function. Inline code documentation also exists for each of the functions.

### Test Plan
- Adds tests for the outputs of a range of sizes
- Adds tests for ranges extending above the size of the collection

### Source Impact
The functionality is purely additive. The behavior of the existing function is unchanged.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
