### PR TITLE
Update README.md to add slidingWindows(ofCount:) and striding(by:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`trimming(where:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end. 
 - [`slidingWindows(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/SlidingWindows.md): Breaks a collection into overlapping contiguous window subsequences where elements are slices from the original collection.
-- [`striding(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Stride.md): Safely and efficiently operate over every `nth` element of a collection.
+- [`striding(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Stride.md): Returns every nth element of a collection.
 
 ## Adding Swift Algorithms as a Dependency
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Read more about the package, and the intent behind it, in the [announcement on s
 - [`chunked(by:)`, `chunked(on:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`trimming(where:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Trim.md): Returns a slice by trimming elements from a collection's start and end. 
-
+- [`slidingWindows(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/SlidingWindows.md): Breaks a collection into overlapping contiguous window subsequences where elements are slices from the original collection.
+- [`striding(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Stride.md): Safely and efficiently operate over every `nth` element of a collection.
 
 ## Adding Swift Algorithms as a Dependency
 


### PR DESCRIPTION
Adds `slidingWindows(ofCount:)` and `striding(by:)` to README.md

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
