### PR TITLE
[NFC] Using precondition instead of assert in calls that do not allow negative values

### DIFF
--- a/Sources/Algorithms/Combinations.swift
+++ b/Sources/Algorithms/Combinations.swift
@@ -286,7 +286,7 @@ extension Collection {
   /// accesses the `count` of the base collection.
   @inlinable
   public func combinations(ofCount k: Int) -> Combinations<Self> {
-    assert(k >= 0, "Can't have combinations with a negative number of elements.")
+    precondition(k >= 0, "Can't have combinations with a negative number of elements.")
     return Combinations(self, k: k)
   }
 }

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -242,7 +242,7 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   public func permutations(ofCount k: Int? = nil) -> Permutations<Self> {
-    assert(
+    precondition(
       k ?? 0 >= 0,
       "Can't have permutations with a negative number of elements.")
     return Permutations(self, k: k)


### PR DESCRIPTION
I think that makes sense to `precondition` instead of `assert` in those cases :) 
It also aligns with we currently have for others like `SlidingWindows`. 

cc @natecook1000 @kylemacomber 
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
