### PR TITLE
Fix RandomSample crash when 0 was out from random.

### DIFF
--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -87,14 +87,15 @@ extension Collection {
 internal func nextW<G: RandomNumberGenerator>(
   k: Int, using rng: inout G
 ) -> Double {
-  Double.root(1 - .random(in: 0..<1, using: &rng), k)
+  Double.root(.random(in: 0..<1, using: &rng), k)
 }
 
 @usableFromInline
 internal func nextOffset<G: RandomNumberGenerator>(
   w: Double, using rng: inout G
 ) -> Int {
-  Int(Double.log(1 - .random(in: 0..<1, using: &rng)) / .log(1 - w))
+  let offset = Double.log(.random(in: 0..<1, using: &rng)) / .log(onePlus: -w)
+  return offset < Double(Int.max) ? Int(offset) : Int.max
 }
 
 extension Collection {
@@ -201,7 +202,7 @@ extension Sequence {
       w *= nextW(k: k, using: &rng)
       
       // Find the offset of the next element to swap into the reservoir.
-      var offset = nextOffset(w: w, using: &rng) + 1
+      var offset = nextOffset(w: w, using: &rng) &+ 1
       
       // Skip over `offset - 1` elements to find the selected element.
       while offset > 1, let _ = iterator.next() {

--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -87,14 +87,14 @@ extension Collection {
 internal func nextW<G: RandomNumberGenerator>(
   k: Int, using rng: inout G
 ) -> Double {
-  Double.root(.random(in: 0..<1, using: &rng), k)
+  Double.root(1 - .random(in: 0..<1, using: &rng), k)
 }
 
 @usableFromInline
 internal func nextOffset<G: RandomNumberGenerator>(
   w: Double, using rng: inout G
 ) -> Int {
-  Int(Double.log(.random(in: 0..<1, using: &rng)) / .log(1 - w))
+  Int(Double.log(1 - .random(in: 0..<1, using: &rng)) / .log(1 - w))
 }
 
 extension Collection {

--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -202,10 +202,10 @@ extension Sequence {
       w *= nextW(k: k, using: &rng)
       
       // Find the offset of the next element to swap into the reservoir.
-      var offset = nextOffset(w: w, using: &rng) &+ 1
+      var offset = nextOffset(w: w, using: &rng)
       
-      // Skip over `offset - 1` elements to find the selected element.
-      while offset > 1, let _ = iterator.next() {
+      // Skip over `offset` elements to find the selected element.
+      while offset > 0, let _ = iterator.next() {
         offset -= 1
       }
       guard let nextElement = iterator.next() else { break }

--- a/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
@@ -101,8 +101,26 @@ final class RandomSampleTests: XCTestCase {
       mutating func next() -> UInt64 { 0 }
     }
     var zero = ZeroGenerator()
-    XCTAssertGreaterThan(nextW(k: 1, using: &zero), 0)
-    XCTAssertGreaterThan(nextW(k: k, using: &zero), 0)
     _ = nextOffset(w: 1, using: &zero) // must not crash
+
+    struct AlmostAllZeroGenerator: RandomNumberGenerator {
+      private var forward: SplitMix64
+      private var count: Int = 0
+
+      init(seed: UInt64) {
+        forward = SplitMix64(seed: seed)
+      }
+
+      mutating func next() -> UInt64 {
+        defer { count &+= 1 }
+        if count % 1000 == 0 { return forward.next() }
+        return 0
+      }
+    }
+
+    var almostAllZero = AlmostAllZeroGenerator(seed: 0)
+    _ = s.randomSample(count: k, using: &almostAllZero) // must not crash
+    almostAllZero = AlmostAllZeroGenerator(seed: 0)
+    _ = c.randomSample(count: k, using: &almostAllZero) // must not crash
   }
 }

--- a/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 func validateRandomSamples<S: Sequence>(
   _ samples: [Int: Int],
@@ -96,8 +96,13 @@ final class RandomSampleTests: XCTestCase {
     XCTAssertEqual(sample1c, sample2c)
   }
 
-  func testRandomSampleZeroRandom() {
-    var generator = SplitMix64(seed: 0x61c8864680b583eb) // this seed starts with 0
-    _ = c.randomSample(count: k, using: &generator) // must not crash
+  func testRandomSampleRandomEdgeCasesInternal() {
+    struct ZeroGenerator: RandomNumberGenerator {
+      mutating func next() -> UInt64 { 0 }
+    }
+    var zero = ZeroGenerator()
+    XCTAssertGreaterThan(nextW(k: 1, using: &zero), 0)
+    XCTAssertGreaterThan(nextW(k: k, using: &zero), 0)
+    _ = nextOffset(w: 1, using: &zero) // must not crash
   }
 }

--- a/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RandomSampleTests.swift
@@ -95,4 +95,9 @@ final class RandomSampleTests: XCTestCase {
     let sample2c = c.randomStableSample(count: k, using: &generator)
     XCTAssertEqual(sample1c, sample2c)
   }
+
+  func testRandomSampleZeroRandom() {
+    var generator = SplitMix64(seed: 0x61c8864680b583eb) // this seed starts with 0
+    _ = c.randomSample(count: k, using: &generator) // must not crash
+  }
 }


### PR DESCRIPTION
Fix https://github.com/apple/swift-algorithms/issues/69 .

I changed the random ranges from `[0, 1)` to `(0, 1]` .
`w` must not be `0` so fixed `nextW` too. (in `log(1 - w)`, `log(1)` is `0` so zero division happens.)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
