### PR TITLE
Add Sequence.uniqued(on:) which uses Key Paths

### DIFF
--- a/Guides/Unique.md
+++ b/Guides/Unique.md
@@ -7,8 +7,8 @@ Methods to strip repeated elements from a sequence or collection.
 
 The `uniqued()` method returns an array, dropping duplicate elements
 from a sequence. The `uniqued(on:)` method does the same, using 
-the result of the given closure to determine the "uniqueness" of each 
-element.
+the result of the given closure, or a key path, to determine the
+"uniqueness" of each element.
 
 ```swift
 let numbers = [1, 2, 3, 3, 2, 3, 3, 2, 2, 2, 1]
@@ -19,8 +19,8 @@ let unique = numbers.uniqued()
 
 ## Detailed Design
 
-Both methods are available for sequences, with the simplest limited to
-when the element type conforms to `Hashable`. Both methods preserve
+The three methods are available for sequences, with the simplest limited to
+when the element type conforms to `Hashable`. These methods preserve
 the relative order of the elements.
 
 ```swift
@@ -30,6 +30,11 @@ extension Sequence where Element: Hashable {
 
 extension Sequence {
     func uniqued<T>(on: (Element) throws -> T) rethrows -> [Element]
+        where T: Hashable
+}
+
+extension Sequence {
+    func uniqued<T>(on: KeyPath<Element, T>) rethrows -> [Element]
         where T: Hashable
 }
 ```

--- a/Sources/Algorithms/Unique.swift
+++ b/Sources/Algorithms/Unique.swift
@@ -66,4 +66,38 @@ extension Sequence {
     }
     return result
   }
+
+  /// Returns an array with the unique elements of this sequence (as determined
+  /// by the given key path), in the order of the first occurrence of each
+  /// unique element.
+  ///
+  /// This example finds the elements of the `animals` array with unique
+  /// first characters:
+  ///
+  ///     let animals = ["dog", "pig", "cat", "ox", "cow", "owl"]
+  ///     let uniqued = animals.uniqued(on: \.first)
+  ///     print(uniqued)
+  ///     // Prints '["dog", "pig", "cat", "ox"]'
+  ///
+  /// - Parameter keyPath: A key path from a specific root type to a specific
+  ///   resulting value type.
+  ///
+  /// - Returns: An array with only the unique elements of this sequence, as
+  ///   determined by the key path of each element.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  @inlinable
+  public func uniqued<Subject: Hashable>(
+    on keyPath: KeyPath<Element, Subject>
+  ) -> [Element] {
+    var seen: Set<Subject> = []
+    var result: [Element] = []
+    for element in self {
+      let value = element[keyPath: keyPath]
+      if seen.insert(value).inserted {
+        result.append(element)
+      }
+    }
+    return result
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/UniqueTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniqueTests.swift
@@ -33,5 +33,8 @@ final class UniqueTests: XCTestCase {
 
     let d = a.uniqued(on: \.first)
     XCTAssertEqual(["Albemarle", "Brandywine"], d)
+
+    let e = a.uniqued(on: \.count)
+    XCTAssertEqual(["Albemarle", "Abeforth", "Brandywine", "Axiom"], e)
   }
 }

--- a/Tests/SwiftAlgorithmsTests/UniqueTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniqueTests.swift
@@ -30,5 +30,8 @@ final class UniqueTests: XCTestCase {
     
     let c: [Int] = []
     XCTAssertEqual(c.uniqued(on: { $0.bitWidth }), [])
+
+    let d = a.uniqued(on: \.first)
+    XCTAssertEqual(["Albemarle", "Brandywine"], d)
   }
 }


### PR DESCRIPTION
### Description

This PR adds a new method to Sequence, `uniqued(on:)`. The method uses a key path to determine the uniqueness of elements in the array.

### Detailed Design

The change adds the following API:

```swift
public func uniqued<Subject: Hashable>(
    on keyPath: KeyPath<Element, Subject>
) -> [Element]
```

### Documentation Plan

Documentation was added to the code and to the guide (`Guides/Unique.md`).

### Test Plan

The method was tested using the same example used by 

```swift
public func uniqued<Subject: Hashable>(
    on projection: (Element) throws -> Subject
) rethrows -> [Element]
```

```swift
let a = ["Albemarle", "Abeforth", "Astrology", "Brandywine", "Beatrice", "Axiom"]
let b = a.uniqued(on: { $0.first })
XCTAssertEqual(["Albemarle", "Brandywine"], b)

let c = a.uniqued(on: \.first)
XCTAssertEqual(["Albemarle", "Brandywine"], d)
```

### Source Impact

Since it's a new method, there's no impact on existing users.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary