### PR TITLE
[0.0.3] Audit public functions and properties that could be inlinable

### DIFF
--- a/Sources/Algorithms/Chain.swift
+++ b/Sources/Algorithms/Chain.swift
@@ -19,6 +19,7 @@ public struct Chain2<Base1: Sequence, Base2: Sequence>
   /// The second sequence in this chain.
   public let base2: Base2
 
+  @usableFromInline
   internal init(base1: Base1, base2: Base2) {
     self.base1 = base1
     self.base2 = base2
@@ -306,6 +307,7 @@ extension Chain2: Hashable where Base1: Hashable, Base2: Hashable {}
 ///   then over the elements of `s2`.
 ///
 /// - Complexity: O(1)
+@inlinable
 public func chain<S1, S2>(_ s1: S1, _ s2: S2) -> Chain2<S1, S2> {
   Chain2(base1: s1, base2: s2)
 }

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -529,6 +529,7 @@ extension ChunkedByCount: Equatable where Base: Equatable {}
 // only in terms of `base`. Since the computed index is based on it,
 // it should not make a difference here.
 extension ChunkedByCount: Hashable where Base: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(base)
   }

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -13,6 +13,11 @@
 public struct Cycle<Base: Collection> {
   /// The collection to repeat.
   public let base: Base
+  
+  @usableFromInline
+  internal init(base: Base) {
+    self.base = base
+  }
 }
 
 extension Cycle: Sequence {
@@ -43,6 +48,7 @@ extension Cycle: Sequence {
     }
   }
   
+  @inlinable
   public func makeIterator() -> Iterator {
     Iterator(base: base)
   }
@@ -80,6 +86,7 @@ extension Collection {
   ///   forever.
   ///
   /// - Complexity: O(1)
+  @inlinable
   public func cycled() -> Cycle<Self> {
     Cycle(base: self)
   }
@@ -101,6 +108,7 @@ extension Collection {
   ///   times.
   ///
   /// - Complexity: O(1)
+  @inlinable
   public func cycled(times: Int) -> FlattenSequence<Repeated<Self>> {
     repeatElement(self, count: times).joined()
   }

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -186,6 +186,7 @@ extension Permutations: Sequence {
     }
   }
   
+  @inlinable
   public func makeIterator() -> Iterator {
     Iterator(self)
   }

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -16,6 +16,7 @@ public struct Product2<Base1: Sequence, Base2: Collection> {
   /// The inner sequence in the product.
   public let base2: Base2
   
+  @usableFromInline
   internal init(_ base1: Base1, _ base2: Base2) {
     self.base1 = base1
     self.base2 = base2
@@ -470,6 +471,7 @@ extension Product2: Hashable where Base1: Hashable, Base2: Hashable {}
 ///   - s2: The second sequence to iterate over.
 ///
 /// - Complexity: O(1)
+@inlinable
 public func product<Base1: Sequence, Base2: Collection>(
   _ s1: Base1, _ s2: Base2
 ) -> Product2<Base1, Base2> {

--- a/Sources/Algorithms/Stride.swift
+++ b/Sources/Algorithms/Stride.swift
@@ -27,6 +27,7 @@ extension Sequence {
   /// - Parameter step: The amount to step with each iteration.
   /// - Returns: Returns a sequence or collection for stepping through the
   /// elements by the specified amount.
+  @inlinable
   public func striding(by step: Int) -> Stride<Self> {
     Stride(base: self, stride: step)
   }
@@ -34,9 +35,13 @@ extension Sequence {
 
 /// A wrapper that strides over a base sequence or collection.
 public struct Stride<Base: Sequence> {
+  @usableFromInline
   internal let base: Base
+  
+  @usableFromInline
   internal let stride: Int
   
+  @usableFromInline
   internal init(base: Base, stride: Int) {
     precondition(stride > 0, "striding must be greater than zero")
     self.base = base
@@ -45,6 +50,7 @@ public struct Stride<Base: Sequence> {
 }
 
 extension Stride {
+  @inlinable
   public func striding(by step: Int) -> Self {
     Stride(base: base, stride: stride * step)
   }
@@ -53,10 +59,22 @@ extension Stride {
 extension Stride: Sequence {
   /// An iterator over a `Stride` sequence.
   public struct Iterator: IteratorProtocol {
+    @usableFromInline
     internal var iterator: Base.Iterator
+    
+    @usableFromInline
     internal let stride: Int
+    
+    @usableFromInline
     internal var striding: Bool = false
     
+    @usableFromInline
+    internal init(iterator: Base.Iterator, stride: Int) {
+      self.iterator = iterator
+      self.stride = stride
+    }
+    
+    @inlinable
     public mutating func next() -> Base.Element? {
       guard striding else {
         striding = true
@@ -69,6 +87,7 @@ extension Stride: Sequence {
     }
   }
   
+  @inlinable
   public func makeIterator() -> Stride<Base>.Iterator {
     Iterator(iterator: base.makeIterator(), stride: stride)
   }
@@ -77,34 +96,42 @@ extension Stride: Sequence {
 extension Stride: Collection where Base: Collection {
   /// A position in a `Stride` collection.
   public struct Index: Comparable {
+    @usableFromInline
     internal let base: Base.Index
     
+    @usableFromInline
     internal init(_ base: Base.Index) {
       self.base = base
     }
     
+    @inlinable
     public static func < (lhs: Index, rhs: Index) -> Bool {
       lhs.base < rhs.base
     }
   }
   
+  @inlinable
   public var startIndex: Index {
     Index(base.startIndex)
   }
   
+  @inlinable
   public var endIndex: Index {
     Index(base.endIndex)
   }
   
+  @inlinable
   public subscript(i: Index) -> Base.Element {
     base[i.base]
   }
   
+  @inlinable
   public func index(after i: Index) -> Index {
     precondition(i.base < base.endIndex, "Advancing past end index")
     return index(i, offsetBy: 1)
   }
   
+  @inlinable
   public func index(
     _ i: Index,
     offsetBy n: Int,
@@ -118,7 +145,8 @@ extension Stride: Collection where Base: Collection {
       : offsetBackward(i, offsetBy: -n, limitedBy: limit)
   }
   
-  private func offsetForward(
+  @usableFromInline
+  internal func offsetForward(
     _ i: Index,
     offsetBy n: Int,
     limitedBy limit: Index
@@ -147,7 +175,8 @@ extension Stride: Collection where Base: Collection {
     }
   }
   
-  private func offsetBackward(
+  @usableFromInline
+  internal func offsetBackward(
     _ i: Index,
     offsetBy n: Int,
     limitedBy limit: Index
@@ -162,15 +191,18 @@ extension Stride: Collection where Base: Collection {
     ).map(Index.init)
   }
   
+  @inlinable
   public var count: Int {
     base.isEmpty ? 0 : (base.count - 1) / stride + 1
   }
   
+  @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     let distance = base.distance(from: start.base, to: end.base)
     return distance / stride + (distance % stride).signum()
   }
   
+  @inlinable
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     precondition(distance <= 0 || i.base < base.endIndex, "Advancing past end index")
     precondition(distance >= 0 || i.base > base.startIndex, "Incrementing past start index")
@@ -183,7 +215,8 @@ extension Stride: Collection where Base: Collection {
 
 extension Stride: BidirectionalCollection
   where Base: RandomAccessCollection {
-
+  
+  @inlinable
   public func index(before i: Index) -> Index {
     precondition(i.base > base.startIndex, "Incrementing past start index")
     return index(i, offsetBy: -1)
@@ -193,12 +226,14 @@ extension Stride: BidirectionalCollection
 extension Stride: RandomAccessCollection where Base: RandomAccessCollection {}
 
 extension Stride: Equatable where Base.Element: Equatable {
+  @inlinable
   public static func == (lhs: Stride, rhs: Stride) -> Bool {
     lhs.elementsEqual(rhs, by: ==)
   }
 }
 
 extension Stride: Hashable where Base.Element: Hashable {
+  @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(stride)
     for element in self {

--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -23,6 +23,7 @@ extension BidirectionalCollection {
   ///   returns `false` it will not be called again.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
   public func suffix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {

--- a/Sources/Algorithms/Windows.swift
+++ b/Sources/Algorithms/Windows.swift
@@ -38,6 +38,7 @@ extension Collection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`, otherwise O(*k*) where `k` is `count`.
   ///   Access to successive windows is O(1).
+  @inlinable
   public func windows(ofCount count: Int) -> Windows<Self> {
     Windows(base: self, size: count)
   }
@@ -49,8 +50,10 @@ public struct Windows<Base: Collection> {
   public let base: Base
   public let size: Int
   
+  @usableFromInline
   internal var firstUpperBound: Base.Index?
 
+  @usableFromInline
   internal init(base: Base, size: Int) {
     precondition(size > 0, "Windows size must be greater than zero")
     self.base = base
@@ -63,18 +66,30 @@ public struct Windows<Base: Collection> {
 extension Windows: Collection {
   /// A position in a `Windows` collection.
   public struct Index: Comparable {
+    @usableFromInline
     internal var lowerBound: Base.Index
+    
+    @usableFromInline
     internal var upperBound: Base.Index
     
+    @usableFromInline
+    internal init(lowerBound: Base.Index, upperBound: Base.Index) {
+      self.lowerBound = lowerBound
+      self.upperBound = upperBound
+    }
+    
+    @inlinable
     public static func == (lhs: Index, rhs: Index) -> Bool {
       lhs.lowerBound == rhs.lowerBound
     }
     
+    @inlinable
     public static func < (lhs: Index, rhs: Index) -> Bool {
       lhs.lowerBound < rhs.lowerBound
     }
   }
   
+  @inlinable
   public var startIndex: Index {
     if let upperBound = firstUpperBound {
       return Index(lowerBound: base.startIndex, upperBound: upperBound)
@@ -83,10 +98,12 @@ extension Windows: Collection {
     }
   }
   
+  @inlinable
   public var endIndex: Index {
     Index(lowerBound: base.endIndex, upperBound: base.endIndex)
   }
   
+  @inlinable
   public subscript(index: Index) -> Base.SubSequence {
     precondition(
       index.lowerBound != index.upperBound,
@@ -94,6 +111,7 @@ extension Windows: Collection {
     return base[index.lowerBound..<index.upperBound]
   }
   
+  @inlinable
   public func index(after index: Index) -> Index {
     precondition(index < endIndex, "Advancing past end index")
     guard index.upperBound < base.endIndex else { return endIndex }
@@ -103,6 +121,7 @@ extension Windows: Collection {
     )
   }
   
+  @inlinable
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     guard distance != 0 else { return i }
     
@@ -111,6 +130,7 @@ extension Windows: Collection {
       : offsetBackward(i, by: -distance)
   }
   
+  @inlinable
   public func index(
     _ i: Index,
     offsetBy distance: Int,
@@ -130,19 +150,22 @@ extension Windows: Collection {
     }
   }
   
-  private func offsetForward(_ i: Index, by distance: Int) -> Index {
+  @usableFromInline
+  internal func offsetForward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
       else { fatalError("Index is out of bounds") }
     return index
   }
   
-  private func offsetBackward(_ i: Index, by distance: Int) -> Index {
+  @usableFromInline
+  internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
       else { fatalError("Index is out of bounds") }
     return index
   }
   
-  private func offsetForward(
+  @usableFromInline
+  internal func offsetForward(
     _ i: Index, by distance: Int, limitedBy limit: Index
   ) -> Index? {
     assert(distance > 0)
@@ -212,7 +235,8 @@ extension Windows: Collection {
     }
   }
   
-  private func offsetBackward(
+  @usableFromInline
+  internal func offsetBackward(
       _ i: Index, by distance: Int, limitedBy limit: Index
     ) -> Index? {
     assert(distance > 0)
@@ -273,6 +297,7 @@ extension Windows: Collection {
     }
   }
   
+  @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     guard start <= end else { return -distance(from: end, to: start) }
     guard start != end else { return 0 }
@@ -302,6 +327,7 @@ extension Windows: Collection {
 }
 
 extension Windows: BidirectionalCollection where Base: BidirectionalCollection {
+  @inlinable
   public func index(before index: Index) -> Index {
     precondition(index > startIndex, "Incrementing past start index")
     if index == endIndex {


### PR DESCRIPTION
Tackle items `Audit inlinability annotations throughout` of #80 

* Make public methods and properties inlinable

Note: I didn't touch `sortedPrefix` file to avoid conflicts with renaming PR in progress =] 
cc @natecook1000 @kylemacomber @timvermeulen 

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
