### PR TITLE
Add uniquePermutations as wrapper for nextPermutation

### DIFF
--- a/Guides/Permutations.md
+++ b/Guides/Permutations.md
@@ -98,7 +98,7 @@ for perm in numbers.permutations(ofCount: 0...) {
 
 ## Detailed Design
 
-The `permutations(ofCount:)` and `uniquePermutations(ofCount:)` methods are declared as a `Collection` extensions,
+The `permutations(ofCount:)` and `uniquePermutations(ofCount:)` methods are declared as `Collection` extensions,
 and return `Permutations` and `UniquePermutations` instances, respectively:
 
 ```swift

--- a/Guides/Permutations.md
+++ b/Guides/Permutations.md
@@ -3,7 +3,7 @@
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Permutations.swift) | 
  [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/PermutationsTests.swift)]
 
-A type that computes permutations of a collection’s elements, or of a subset of
+Methods that compute permutations of a collection’s elements, or of a subset of
 those elements.
 
 The `permutations(ofCount:)` method, when called without the `ofCount`
@@ -60,7 +60,18 @@ for perm in numbers2.permutations() {
 // [10, 10, 20]
 ```
 
-Given a range, the `permutations(ofCount:)` method returns a sequence of all the different permutations of the given sizes of a collection’s elements in increasing order of size.
+To generate only unique permutations, use the `uniquePermutations(ofCount:)` method:
+
+```swift
+for perm in numbers2.uniquePermutations() {
+    print(perm)
+}
+// [20, 10, 10]
+// [10, 20, 10]
+// [10, 10, 20]
+```
+
+Given a range, the methods return a sequence of all the different permutations of the given sizes of a collection’s elements in increasing order of size.
 
 ```swift
 let numbers = [10, 20, 30]
@@ -87,27 +98,39 @@ for perm in numbers.permutations(ofCount: 0...) {
 
 ## Detailed Design
 
-The `permutations(ofCount:)` method is declared as a `Collection` extension,
-and returns a `Permutations` type:
+The `permutations(ofCount:)` and `uniquePermutations(ofCount:)` methods are declared as a `Collection` extensions,
+and return `Permutations` and `UniquePermutations` instances, respectively:
 
 ```swift
 extension Collection {
     public func permutations(ofCount k: Int? = nil) -> Permutations<Self>
+    public func permutations<R>(ofCount kRange: R) -> Permutations<Self>
+        where R: RangeExpression, R.Bound == Int
+}
+
+extension Collection where Element: Hashable {
+    public func uniquePermutations(ofCount k: Int? = nil) -> UniquePermutations<Self>
+    public func uniquePermutations<R>(ofCount kRange: R) -> UniquePermutations<Self>
+        where R: RangeExpression, R.Bound == Int
 }
 ```
 
-Since the `Permutations` type needs to store an array of the collection’s
-indices and mutate the array to generate each permutation, `Permutations` only
-has `Sequence` conformance. Adding `Collection` conformance would require
+Since both result types need to store an array of the collection’s
+indices and mutate the array to generate each permutation, they only
+have `Sequence` conformance. Adding `Collection` conformance would require
 storing the array in the index type, which would in turn lead to copying the
-array at every index advancement. `Combinations` does conform to
-`LazySequenceProtocol` when the base type conforms.
+array at every index advancement. The `Permutations` type
+conforms to `LazySequenceProtocol` when its base type conforms.
 
 ### Complexity
 
 Calling `permutations()` is an O(1) operation. Creating the iterator for a
 `Permutations` instance and each call to `Permutations.Iterator.next()` is an
 O(_n_) operation.
+
+Calling `uniquePermutations()` is an O(_n_) operation, because it preprocesses the
+collection to find duplicate elements. Creating the iterator for and each call to 
+`next()` is also an O(_n_) operation.
 
 ### Naming
 
@@ -117,9 +140,8 @@ See the ["Naming" section for `combinations(ofCount:)`](Combinations.md#naming) 
 
 **C++:** The `<algorithm>` library defines a `next_permutation` function that
 advances an array of comparable values through their lexicographic orderings.
-This function is tricky to use and understand, so while it’s included in
-`swift-algorithms` as an implementation detail of the `Permutations` type, it
-isn’t public.
+This function is very similar to the `uniquePermutations(ofCount:)` method.
 
 **Rust/Ruby/Python:** Rust, Ruby, and Python all define functions with
-essentially the same semantics as the method described here.
+essentially the same semantics as the `permutations(ofCount:)` method 
+described here.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 - [`combinations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Combinations.md): Combinations of particular sizes of the elements in a collection.
 - [`permutations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Permutations.md): Permutations of a particular size of the elements in a collection, or of the full collection.
+- [`uniquePermutations(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Permutations.md): Permutations of a collection's elements, skipping any duplicate permutations.
 
 #### Mutating algorithms
 

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -359,3 +359,82 @@ extension Collection {
     return Permutations(self, k: k)
   }
 }
+
+//===----------------------------------------------------------------------===//
+// uniquePermutations()
+//===----------------------------------------------------------------------===//
+
+public struct UniquePermutations<Element: Comparable> {
+  @usableFromInline
+  let elements: [Element]
+  
+  @inlinable
+  init<S: Sequence>(_ elements: S) where S.Element == Element {
+    self.elements = elements.sorted()
+  }
+}
+
+extension UniquePermutations: Sequence {
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    var elements: [Element]
+    
+    @usableFromInline
+    var finished = false
+    
+    @inlinable
+    init(_ elements: [Element]) {
+      self.elements = elements
+    }
+    
+    @inlinable
+    public mutating func next() -> [Element]? {
+      if finished {
+        return nil
+      } else {
+        defer { finished = !elements.nextPermutation() }
+        return elements
+      }
+    }
+  }
+  
+  @inlinable
+  public func makeIterator() -> Iterator {
+    Iterator(elements)
+  }
+}
+
+extension Sequence where Element: Comparable {
+  /// Returns a sequence of the unique permutations of this sequence.
+  ///
+  /// Use this method to iterate over the unique permutations of a sequence
+  /// with repeating elements. This example prints every permutation of an
+  /// array of numbers:
+  ///
+  ///     let numbers = [1, 2, 2]
+  ///     for perm in numbers.uniquePermutations() {
+  ///         print(perm)
+  ///     }
+  ///     // [1, 2, 2]
+  ///     // [2, 1, 2]
+  ///     // [2, 2, 1]
+  ///
+  /// By contrast, the unadorned `permutations()` method permutes over a
+  /// collection by position, which includes permutations with equal elements
+  /// in each permutation:
+  ///
+  ///     for perm in numbers.permutations()
+  ///         print(perm)
+  ///     }
+  ///     // [1, 2, 2]
+  ///     // [1, 2, 2]
+  ///     // [2, 1, 2]
+  ///     // [2, 2, 1]
+  ///     // [2, 1, 2]
+  ///     // [2, 2, 1]
+  ///
+  /// The returned permutations are in lexicographically sorted order.
+  public func uniquePermutations() -> UniquePermutations<Element> {
+    UniquePermutations(self)
+  }
+}

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -316,34 +316,37 @@ extension Collection {
   ///     // Davide, Celeste
   ///
   /// This example prints _all_ the permutations (including an empty array) from
-  /// the an array of numbers:
+  /// an array of numbers:
   ///
   ///     let numbers = [10, 20, 30]
-  ///    for perm in numbers.permutations(ofCount: 0...) {
-  ///        print(perm)
-  ///    }
-  ///    // []
-  ///    // [10]
-  ///    // [20]
-  ///    // [30]
-  ///    // [10, 20]
-  ///    // [10, 30]
-  ///    // [20, 10]
-  ///    // [20, 30]
-  ///    // [30, 10]
-  ///    // [30, 20]
-  ///    // [10, 20, 30]
-  ///    // [10, 30, 20]
-  ///    // [20, 10, 30]
-  ///    // [20, 30, 10]
-  ///    // [30, 10, 20]
-  ///    // [30, 20, 10]
+  ///     for perm in numbers.permutations(ofCount: 0...) {
+  ///         print(perm)
+  ///     }
+  ///     // []
+  ///     // [10]
+  ///     // [20]
+  ///     // [30]
+  ///     // [10, 20]
+  ///     // [10, 30]
+  ///     // [20, 10]
+  ///     // [20, 30]
+  ///     // [30, 10]
+  ///     // [30, 20]
+  ///     // [10, 20, 30]
+  ///     // [10, 30, 20]
+  ///     // [20, 10, 30]
+  ///     // [20, 30, 10]
+  ///     // [30, 10, 20]
+  ///     // [30, 20, 10]
+  ///
+  /// The returned permutations are in ascending order by length, and then
+  /// lexicographically within each group of the same length.
   ///
   /// - Parameter kRange: The number of elements to include in each permutation.
   ///
   /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
-  /// is the number of elements in the base collection, since `Permutations`
-  /// accesses the `count` of the base collection.
+  ///   is the number of elements in the base collection, since `Permutations`
+  ///   accesses the `count` of the base collection.
   @inlinable
   public func permutations<R: RangeExpression>(
     ofCount kRange: R
@@ -412,6 +415,11 @@ extension Collection {
 // uniquePermutations()
 //===----------------------------------------------------------------------===//
 
+/// A sequence of the unique permutations of the elements of a sequence or
+/// collection.
+///
+/// To create a `UniquePermutations` instance, call one of the
+/// `uniquePermutations` methods on your collection.
 public struct UniquePermutations<Element> {
   @usableFromInline
   internal let elements: [Element]
@@ -441,6 +449,7 @@ public struct UniquePermutations<Element> {
 }
 
 extension UniquePermutations: Sequence {
+  /// The iterator for a `UniquePermutations` instance.
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     var elements: [Element]
@@ -510,9 +519,9 @@ extension Sequence where Element: Comparable {
   ///     // [2, 1, 2]
   ///     // [2, 2, 1]
   ///
-  /// By contrast, the unadorned `permutations()` method permutes over a
-  /// collection by position, which includes permutations with equal elements
-  /// in each permutation:
+  /// By contrast, the unadorned `permutations()` method permutes a collection's
+  /// elements by position, and includes permutations with equal elements in
+  /// each permutation:
   ///
   ///     for perm in numbers.permutations()
   ///         print(perm)
@@ -529,10 +538,60 @@ extension Sequence where Element: Comparable {
     UniquePermutations(self, by: <)
   }
 
+  /// Returns a sequence of the unique permutations of this sequence of the
+  /// specified length.
+  ///
+  /// Use this method to iterate over the unique permutations of a sequence
+  /// with repeating elements. This example prints every unique two-element
+  /// permutation of an array of numbers:
+  ///
+  ///     let numbers = [1, 1, 2]
+  ///     for perm in numbers.uniquePermutations(ofCount: 2) {
+  ///         print(perm)
+  ///     }
+  ///     // [1, 1]
+  ///     // [1, 2]
+  ///     // [2, 1]
+  ///
+  /// By contrast, the `permutations(ofCount:)` method permutes a collection's
+  /// elements by position, and can include permutations with equal elements
+  /// in each permutation:
+  ///
+  ///     for perm in numbers.permutations(ofCount: 2)
+  ///         print(perm)
+  ///     }
+  ///     // [1, 1]
+  ///     // [1, 1]
+  ///     // [1, 2]
+  ///     // [1, 2]
+  ///     // [2, 1]
+  ///     // [2, 1]
+  ///
+  /// The returned permutations are in lexicographically sorted order.
   public func uniquePermutations(ofCount k: Int) -> UniquePermutations<Element> {
     UniquePermutations(self, k ..< (k + 1), by: <)
   }
 
+  /// Returns a collection of the unique permutations of this sequence with
+  /// lengths in the specified range.
+  ///
+  /// Use this method to iterate over the unique permutations of a sequence
+  /// with repeating elements. This example prints every unique permutation
+  /// of an array of numbers with lengths through 2 elements:
+  ///
+  ///     let numbers = [1, 1, 2]
+  ///     for perm in numbers.uniquePermutations(ofCount: ...2) {
+  ///         print(perm)
+  ///     }
+  ///     // []
+  ///     // [1]
+  ///     // [2]
+  ///     // [1, 1]
+  ///     // [1, 2]
+  ///     // [2, 1]
+  ///
+  /// The returned permutations are in ascending order by length, and then
+  /// lexicographically within each group of the same length.
   public func uniquePermutations<R: RangeExpression>(ofCount kRange: R) -> UniquePermutations<Element>
     where R.Bound == Int
   {
@@ -541,15 +600,29 @@ extension Sequence where Element: Comparable {
 }
 
 extension Sequence {
-  public func uniquePermutations(by areInIncreasingOrder: @escaping (Element, Element) -> Bool) -> UniquePermutations<Element> {
+  /// Returns a sequence of the unique permutations of this sequence.
+  public func uniquePermutations(
+    by areInIncreasingOrder: @escaping (Element, Element) -> Bool
+  ) -> UniquePermutations<Element> {
     UniquePermutations(self, by: areInIncreasingOrder)
   }
 
-  public func uniquePermutations(ofCount k: Int, by areInIncreasingOrder: @escaping (Element, Element) -> Bool) -> UniquePermutations<Element> {
+  /// Returns a sequence of the unique permutations of this sequence of the
+  /// specified length.
+  ///
+  public func uniquePermutations(
+    ofCount k: Int,
+    by areInIncreasingOrder: @escaping (Element, Element) -> Bool
+  ) -> UniquePermutations<Element> {
     UniquePermutations(self, k ..< (k + 1), by: areInIncreasingOrder)
   }
 
-  public func uniquePermutations<R: RangeExpression>(ofCount kRange: R, by areInIncreasingOrder: @escaping (Element, Element) -> Bool) -> UniquePermutations<Element>
+  /// Returns a collection of the unique permutations of this sequence with
+  /// lengths in the specified range.
+  public func uniquePermutations<R: RangeExpression>(
+    ofCount kRange: R,
+    by areInIncreasingOrder: @escaping (Element, Element) -> Bool
+  ) -> UniquePermutations<Element>
     where R.Bound == Int
   {
     UniquePermutations(self, kRange, by: areInIncreasingOrder)

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -29,36 +29,6 @@ extension MutableCollection
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  internal mutating func nextPermutation2() -> Bool {
-    // Ensure we have > 1 element in the collection.
-    guard !isEmpty else { return false }
-    var i = index(before: endIndex)
-    if i == startIndex { return false }
-    
-    while true {
-      let ip1 = i
-      formIndex(before: &i)
-      
-      if self[i] < self[ip1] {
-        var j = index(before: endIndex)
-        while self[i] >= self[j] {
-          formIndex(before: &j)
-        }
-        swapAt(i, j)
-        self.reverse(subrange: ip1 ..< endIndex)
-        
-        // check here if i < the prefix, if so, return true, if not, continue
-        return true
-      }
-      
-      if i == startIndex {
-        self.reverse()
-        return false
-      }
-    }
-  }
-
-  @inlinable
   internal mutating func nextPermutation(upperBound: Index? = nil) -> Bool {
     // Ensure we have > 1 element in the collection.
     guard !isEmpty else { return false }

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -408,15 +408,14 @@ public struct UniquePermutations<Base: Collection> {
 
 extension UniquePermutations where Base.Element: Hashable {
   @inlinable
-  static func _indexes(_ elements: Base) -> [Base.Index] {
+  internal static func _indexes(_ elements: Base) -> [Base.Index] {
     let firstIndexesAndCountsByElement = Dictionary(
       elements.indices.lazy.map { (elements[$0], ($0, 1)) },
       uniquingKeysWith: { indexAndCount, _ in (indexAndCount.0, indexAndCount.1 + 1) })
     
-    return Array(firstIndexesAndCountsByElement
+    return firstIndexesAndCountsByElement
       .values.sorted(by: { $0.0 < $1.0 })
-      .map { index, count in repeatElement(index, count: count) }
-      .joined())
+      .flatMap { index, count in repeatElement(index, count: count) }
   }
   
   @inlinable
@@ -478,7 +477,7 @@ extension UniquePermutations: Sequence {
       }
 
       if !indexes.nextPermutation(upperBound: lengths.lowerBound) {
-        lengths = (lengths.lowerBound + 1)..<lengths.upperBound
+        lengths.removeFirst()
 
         if lengths.isEmpty {
           return nil

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -395,16 +395,18 @@ extension Collection {
 ///
 /// To create a `UniquePermutations` instance, call one of the
 /// `uniquePermutations` methods on your collection.
-public struct UniquePermutations<Base: Collection> where Base.Element: Hashable {
-  @usableFromInline
-  internal let elements: Base
+public struct UniquePermutations<Base: Collection> {
+  /// The base collection to iterate over for permutations.
+  public let elements: Base
   
   @usableFromInline
   internal var indexes: [Base.Index]
   
   @usableFromInline
   internal let kRange: Range<Int>
+}
 
+extension UniquePermutations where Base.Element: Hashable {
   @inlinable
   static func _indexes(_ elements: Base) -> [Base.Index] {
     let firstIndexesAndCountsByElement = Dictionary(
@@ -438,8 +440,6 @@ public struct UniquePermutations<Base: Collection> where Base.Element: Hashable 
 }
 
 extension UniquePermutations: Sequence {
-  public typealias Element = [Base.Element]
-
   /// The iterator for a `UniquePermutations` instance.
   public struct Iterator: IteratorProtocol {
     @usableFromInline
@@ -494,6 +494,13 @@ extension UniquePermutations: Sequence {
     Iterator(elements, indexes: indexes, lengths: kRange)
   }
 }
+
+// FIXME: Why isn't Permutations running into this error?
+//
+//     error: 'LazySequenceProtocol' requires the types 'Array<Base.Element>' and 'Base.Element' be equivalent
+//     note: requirement specified as 'Self.Element' == 'Self.Elements.Element' [with Self = UniquePermutations<Base>]
+//
+// extension UniquePermutations: LazySequenceProtocol where Base: LazySequenceProtocol {}
 
 extension Collection where Element: Hashable {
   /// Returns a sequence of the unique permutations of this sequence of the

--- a/Sources/Algorithms/Permutations.swift
+++ b/Sources/Algorithms/Permutations.swift
@@ -342,7 +342,11 @@ extension Collection {
   /// The returned permutations are in ascending order by length, and then
   /// lexicographically within each group of the same length.
   ///
-  /// - Parameter kRange: The number of elements to include in each permutation.
+  /// - Parameter kRange: A range of the number of elements to include in each
+  ///   permutation. `kRange` can be any integer range expression, and is
+  ///   clamped to the number of elements in this collection. Passing a range
+  ///   covering sizes greater than the number of elements in this collection
+  ///   results in an empty sequence.
   ///
   /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
   ///   is the number of elements in the base collection, since `Permutations`
@@ -397,11 +401,12 @@ extension Collection {
   ///
   /// - Parameter k: The number of elements to include in each permutation.
   ///   If `k` is `nil`, the resulting sequence represents permutations of this
-  ///   entire collection.
+  ///   entire collection. If `k` is greater than the number of elements in
+  ///   this collection, the resulting sequence is empty.
   ///
   /// - Complexity: O(1) for random-access base collections. O(*n*) where *n*
-  /// is the number of elements in the base collection, since `Permutations`
-  /// accesses the `count` of the base collection.
+  ///   is the number of elements in the base collection, since `Permutations`
+  ///   accesses the `count` of the base collection.
   @inlinable
   public func permutations(ofCount k: Int? = nil) -> Permutations<Self> {
     precondition(
@@ -551,6 +556,14 @@ extension Collection where Element: Hashable {
   ///     // [2, 1]
   ///
   /// The returned permutations are in lexicographically sorted order.
+  ///
+  /// - Parameter k: The number of elements to include in each permutation.
+  ///   If `k` is `nil`, the resulting sequence represents permutations of this
+  ///   entire collection. If `k` is greater than the number of elements in
+  ///   this collection, the resulting sequence is empty.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of elements in this
+  ///   collection.
   public func uniquePermutations(ofCount k: Int? = nil) -> UniquePermutations<Self> {
     if let k = k {
       return UniquePermutations(self, k ..< (k + 1))
@@ -579,6 +592,15 @@ extension Collection where Element: Hashable {
   ///
   /// The returned permutations are in ascending order by length, and then
   /// lexicographically within each group of the same length.
+  ///
+  /// - Parameter kRange: A range of the number of elements to include in each
+  ///   permutation. `kRange` can be any integer range expression, and is
+  ///   clamped to the number of elements in this collection. Passing a range
+  ///   covering sizes greater than the number of elements in this collection
+  ///   results in an empty sequence.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of elements in this
+  ///   collection.
   public func uniquePermutations<R: RangeExpression>(ofCount kRange: R) -> UniquePermutations<Self>
     where R.Bound == Int
   {

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -60,7 +60,9 @@ final class UniquePermutationsTests: XCTestCase {
   static var numbersAndNilsPermutations: [[ArraySlice<Int?>]] {
     numbersPermutations.map { $0.map { ArraySlice($0.map { $0 == 1 ? nil : $0 }) }}
   }
+}
 
+extension UniquePermutationsTests {
   func testEmpty() {
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(), [[]])
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 0), [[]])

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -12,18 +12,10 @@
 import XCTest
 import Algorithms
 
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case (let lhs?, let rhs?): return lhs < rhs
-  case (nil, _?): return true
-  case (_, nil): return false
-  }
-}
-
 final class UniquePermutationsTests: XCTestCase {
   static let numbers = [1, 1, 1, 2, 3]
   
-  static let numbersPermutations: [[ArraySlice<Int>]] = [
+  static let numbersPermutations: [[[Int]]] = [
     // 0
     [[]],
     // 1
@@ -96,39 +88,39 @@ extension UniquePermutationsTests {
     }
   }
 
-  func testEmptyWithPredicate() {
-    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(by: <), [[]])
-    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 0, by: <), [[]])
-    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1, by: <), [])
-    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1...3, by: <), [])
-  }
-  
-  func testSingleCountsWithPredicate() {
-    for (k, expectation) in Self.numbersAndNilsPermutations.enumerated() {
-      XCTAssertEqualSequences(expectation, Self.numbersAndNils.uniquePermutations(ofCount: k, by: <))
-    }
-  }
-
-  func testRangesWithPredicate() {
-    let numbersAndNils = Self.numbersAndNils
-    let numbersAndNilsPermutations = Self.numbersAndNilsPermutations
-    
-    for lower in numbersAndNilsPermutations.indices {
-      // upper bounded
-      XCTAssertEqualSequences(
-        numbersAndNilsPermutations[...lower].joined(),
-        numbersAndNils.uniquePermutations(ofCount: ...lower, by: <))
-      
-      // lower bounded
-      XCTAssertEqualSequences(
-        numbersAndNilsPermutations[lower...].joined(),
-        numbersAndNils.uniquePermutations(ofCount: lower..., by: <))
-
-      for upper in lower..<numbersAndNilsPermutations.count {
-        XCTAssertEqualSequences(
-          numbersAndNilsPermutations[lower..<upper].joined(),
-          numbersAndNils.uniquePermutations(ofCount: lower..<upper, by: <))
-      }
-    }
-  }
+//  func testEmptyWithPredicate() {
+//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(by: <), [[]])
+//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 0, by: <), [[]])
+//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1, by: <), [])
+//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1...3, by: <), [])
+//  }
+//
+//  func testSingleCountsWithPredicate() {
+//    for (k, expectation) in Self.numbersAndNilsPermutations.enumerated() {
+//      XCTAssertEqualSequences(expectation, Self.numbersAndNils.uniquePermutations(ofCount: k, by: <))
+//    }
+//  }
+//
+//  func testRangesWithPredicate() {
+//    let numbersAndNils = Self.numbersAndNils
+//    let numbersAndNilsPermutations = Self.numbersAndNilsPermutations
+//
+//    for lower in numbersAndNilsPermutations.indices {
+//      // upper bounded
+//      XCTAssertEqualSequences(
+//        numbersAndNilsPermutations[...lower].joined(),
+//        numbersAndNils.uniquePermutations(ofCount: ...lower, by: <))
+//
+//      // lower bounded
+//      XCTAssertEqualSequences(
+//        numbersAndNilsPermutations[lower...].joined(),
+//        numbersAndNils.uniquePermutations(ofCount: lower..., by: <))
+//
+//      for upper in lower..<numbersAndNilsPermutations.count {
+//        XCTAssertEqualSequences(
+//          numbersAndNilsPermutations[lower..<upper].joined(),
+//          numbersAndNils.uniquePermutations(ofCount: lower..<upper, by: <))
+//      }
+//    }
+//  }
 }

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -16,7 +16,7 @@ final class UniquePermutationsTests: XCTestCase {
   static let numbers = [1, 1, 1, 2, 3]
   
   static let numbersPermutations: [[[Int]]] = [
-    // 0
+    // k = 0
     [[]],
     // 1
     [[1], [2], [3]],
@@ -44,14 +44,6 @@ final class UniquePermutationsTests: XCTestCase {
      [2, 1, 1, 1, 3], [2, 1, 1, 3, 1], [2, 1, 3, 1, 1], [2, 3, 1, 1, 1],
      [3, 1, 1, 1, 2], [3, 1, 1, 2, 1], [3, 1, 2, 1, 1], [3, 2, 1, 1, 1]]
   ]
-  
-  static var numbersAndNils: [Int?] {
-    numbers.map { $0 == 1 ? nil : $0 }
-  }
-  
-  static var numbersAndNilsPermutations: [[ArraySlice<Int?>]] {
-    numbersPermutations.map { $0.map { ArraySlice($0.map { $0 == 1 ? nil : $0 }) }}
-  }
 }
 
 extension UniquePermutationsTests {
@@ -59,13 +51,20 @@ extension UniquePermutationsTests {
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(), [[]])
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 0), [[]])
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 1), [])
-    XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 1...3), [])
+    XCTAssertEqualSequences(
+      ([] as [Int]).uniquePermutations(ofCount: 1...3), [])
   }
   
   func testSingleCounts() {
     for (k, expectation) in Self.numbersPermutations.enumerated() {
-      XCTAssertEqualSequences(expectation, Self.numbers.uniquePermutations(ofCount: k))
+      XCTAssertEqualSequences(
+        expectation,
+        Self.numbers.uniquePermutations(ofCount: k))
     }
+    
+    XCTAssertEqualSequences(
+      Self.numbersPermutations[5],
+      Self.numbers.uniquePermutations())
   }
   
   func testRanges() {
@@ -87,40 +86,31 @@ extension UniquePermutationsTests {
       }
     }
   }
+}
 
-//  func testEmptyWithPredicate() {
-//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(by: <), [[]])
-//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 0, by: <), [[]])
-//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1, by: <), [])
-//    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1...3, by: <), [])
-//  }
-//
-//  func testSingleCountsWithPredicate() {
-//    for (k, expectation) in Self.numbersAndNilsPermutations.enumerated() {
-//      XCTAssertEqualSequences(expectation, Self.numbersAndNils.uniquePermutations(ofCount: k, by: <))
-//    }
-//  }
-//
-//  func testRangesWithPredicate() {
-//    let numbersAndNils = Self.numbersAndNils
-//    let numbersAndNilsPermutations = Self.numbersAndNilsPermutations
-//
-//    for lower in numbersAndNilsPermutations.indices {
-//      // upper bounded
-//      XCTAssertEqualSequences(
-//        numbersAndNilsPermutations[...lower].joined(),
-//        numbersAndNils.uniquePermutations(ofCount: ...lower, by: <))
-//
-//      // lower bounded
-//      XCTAssertEqualSequences(
-//        numbersAndNilsPermutations[lower...].joined(),
-//        numbersAndNils.uniquePermutations(ofCount: lower..., by: <))
-//
-//      for upper in lower..<numbersAndNilsPermutations.count {
-//        XCTAssertEqualSequences(
-//          numbersAndNilsPermutations[lower..<upper].joined(),
-//          numbersAndNils.uniquePermutations(ofCount: lower..<upper, by: <))
-//      }
-//    }
-//  }
+extension UniquePermutationsTests {
+  private final class IntBox: Hashable {
+    var value: Int
+    
+    init(_ value: Int) {
+      self.value = value
+    }
+    
+    static func == (lhs: IntBox, rhs: IntBox) -> Bool {
+      lhs.value == rhs.value
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(value)
+    }
+  }
+
+  func testFirstUnique() {
+    let numbers = Self.numbers.map(IntBox.init)
+    for k in 0...numbers.count {
+      for p in numbers.uniquePermutations(ofCount: k) {
+        XCTAssertTrue(p.filter { $0.value == 1 }.allSatisfy { $0 === numbers[0] })
+      }
+    }
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -10,7 +10,15 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import Algorithms
+import Algorithms
+
+fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case (let lhs?, let rhs?): return lhs < rhs
+  case (nil, _?): return true
+  case (_, nil): return false
+  }
+}
 
 final class UniquePermutationsTests: XCTestCase {
   static let numbers = [1, 1, 1, 2, 3]
@@ -44,6 +52,14 @@ final class UniquePermutationsTests: XCTestCase {
      [2, 1, 1, 1, 3], [2, 1, 1, 3, 1], [2, 1, 3, 1, 1], [2, 3, 1, 1, 1],
      [3, 1, 1, 1, 2], [3, 1, 1, 2, 1], [3, 1, 2, 1, 1], [3, 2, 1, 1, 1]]
   ]
+  
+  static var numbersAndNils: [Int?] {
+    numbers.map { $0 == 1 ? nil : $0 }
+  }
+  
+  static var numbersAndNilsPermutations: [[ArraySlice<Int?>]] {
+    numbersPermutations.map { $0.map { ArraySlice($0.map { $0 == 1 ? nil : $0 }) }}
+  }
 
   func testEmpty() {
     XCTAssertEqualSequences(([] as [Int]).uniquePermutations(), [[]])
@@ -74,6 +90,42 @@ final class UniquePermutationsTests: XCTestCase {
         XCTAssertEqualSequences(
           Self.numbersPermutations[lower..<upper].joined(),
           Self.numbers.uniquePermutations(ofCount: lower..<upper))
+      }
+    }
+  }
+
+  func testEmptyWithPredicate() {
+    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(by: <), [[]])
+    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 0, by: <), [[]])
+    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1, by: <), [])
+    XCTAssertEqualSequences(([] as [Int?]).uniquePermutations(ofCount: 1...3, by: <), [])
+  }
+  
+  func testSingleCountsWithPredicate() {
+    for (k, expectation) in Self.numbersAndNilsPermutations.enumerated() {
+      XCTAssertEqualSequences(expectation, Self.numbersAndNils.uniquePermutations(ofCount: k, by: <))
+    }
+  }
+
+  func testRangesWithPredicate() {
+    let numbersAndNils = Self.numbersAndNils
+    let numbersAndNilsPermutations = Self.numbersAndNilsPermutations
+    
+    for lower in numbersAndNilsPermutations.indices {
+      // upper bounded
+      XCTAssertEqualSequences(
+        numbersAndNilsPermutations[...lower].joined(),
+        numbersAndNils.uniquePermutations(ofCount: ...lower, by: <))
+      
+      // lower bounded
+      XCTAssertEqualSequences(
+        numbersAndNilsPermutations[lower...].joined(),
+        numbersAndNils.uniquePermutations(ofCount: lower..., by: <))
+
+      for upper in lower..<numbersAndNilsPermutations.count {
+        XCTAssertEqualSequences(
+          numbersAndNilsPermutations[lower..<upper].joined(),
+          numbersAndNils.uniquePermutations(ofCount: lower..<upper, by: <))
       }
     }
   }

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import Algorithms
+
+final class UniquePermutationsTests: XCTestCase {
+  static let numbers = [1, 1, 1, 2, 3]
+  
+  static let numbersPermutations: [[ArraySlice<Int>]] = [
+    // 0
+    [[]],
+    // 1
+    [[1], [2], [3]],
+    // 2
+    [[1, 1], [1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]],
+    // 3
+    [[1, 1, 1], [1, 1, 2], [1, 1, 3],
+     [1, 2, 1], [1, 2, 3], [1, 3, 1], [1, 3, 2],
+     [2, 1, 1], [2, 1, 3], [2, 3, 1],
+     [3, 1, 1], [3, 1, 2], [3, 2, 1]],
+    // 4
+    [[1, 1, 1, 2], [1, 1, 1, 3],
+     [1, 1, 2, 1], [1, 1, 2, 3],
+     [1, 1, 3, 1], [1, 1, 3, 2],
+     [1, 2, 1, 1], [1, 2, 1, 3], [1, 2, 3, 1],
+     [1, 3, 1, 1], [1, 3, 1, 2], [1, 3, 2, 1],
+     [2, 1, 1, 1], [2, 1, 1, 3], [2, 1, 3, 1], [2, 3, 1, 1],
+     [3, 1, 1, 1], [3, 1, 1, 2], [3, 1, 2, 1], [3, 2, 1, 1]],
+    // 5
+    [[1, 1, 1, 2, 3], [1, 1, 1, 3, 2],
+     [1, 1, 2, 1, 3], [1, 1, 2, 3, 1],
+     [1, 1, 3, 1, 2], [1, 1, 3, 2, 1],
+     [1, 2, 1, 1, 3], [1, 2, 1, 3, 1], [1, 2, 3, 1, 1],
+     [1, 3, 1, 1, 2], [1, 3, 1, 2, 1], [1, 3, 2, 1, 1],
+     [2, 1, 1, 1, 3], [2, 1, 1, 3, 1], [2, 1, 3, 1, 1], [2, 3, 1, 1, 1],
+     [3, 1, 1, 1, 2], [3, 1, 1, 2, 1], [3, 1, 2, 1, 1], [3, 2, 1, 1, 1]]
+  ]
+
+  func testEmpty() {
+    XCTAssertEqualSequences(([] as [Int]).uniquePermutations(), [[]])
+    XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 0), [[]])
+    XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 1), [])
+    XCTAssertEqualSequences(([] as [Int]).uniquePermutations(ofCount: 1...3), [])
+  }
+  
+  func testSingleCounts() {
+    for (k, expectation) in Self.numbersPermutations.enumerated() {
+      XCTAssertEqualSequences(expectation, Self.numbers.uniquePermutations(ofCount: k))
+    }
+  }
+  
+  func testRanges() {
+    for lower in Self.numbersPermutations.indices {
+      // upper bounded
+      XCTAssertEqualSequences(
+        Self.numbersPermutations[...lower].joined(),
+        Self.numbers.uniquePermutations(ofCount: ...lower))
+      
+      // lower bounded
+      XCTAssertEqualSequences(
+        Self.numbersPermutations[lower...].joined(),
+        Self.numbers.uniquePermutations(ofCount: lower...))
+
+      for upper in lower..<Self.numbersPermutations.count {
+        XCTAssertEqualSequences(
+          Self.numbersPermutations[lower..<upper].joined(),
+          Self.numbers.uniquePermutations(ofCount: lower..<upper))
+      }
+    }
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -115,4 +115,8 @@ extension UniquePermutationsTests {
       }
     }
   }
+  
+  func testLaziness() {
+    XCTAssertLazySequence("ABCD".lazy.uniquePermutations())
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/UniquePermutationsTests.swift
@@ -106,6 +106,8 @@ extension UniquePermutationsTests {
   }
 
   func testFirstUnique() {
+    // When duplicate elements are encountered, all permutations use the first
+    // instance of the duplicated elements.
     let numbers = Self.numbers.map(IntBox.init)
     for k in 0...numbers.count {
       for p in numbers.uniquePermutations(ofCount: k) {


### PR DESCRIPTION
### Description
Adds methods for generating the unique permutations of a sequence, as distinct from the position-based permutations generated by `permutations()`.

### Detailed Design
Includes new `uniquePermutations(ofCount:)` methods (for both single counts and range expressions) and the wrapping `UniquePermutations` type. The method requires that a collection's elements be hashable so that uniqueness can be determined in a pre-processing pass:

```swift
extension Collection where Element: Hashable {
  /// Returns a sequence of the unique permutations of this collection.
  ///
  /// Use this method to iterate over the unique permutations of a sequence
  /// with repeating elements. This example prints every permutation of an
  /// array of numbers:
  ///
  ///     let numbers = [1, 2, 2]
  ///     for perm in numbers.uniquePermutations() {
  ///         print(perm)
  ///     }
  ///     // [1, 2, 2]
  ///     // [2, 1, 2]
  ///     // [2, 2, 1]
  public func uniquePermutations(ofCount k: Int) -> UniquePermutations<Element>

  public func uniquePermutations<R>(ofCount k: Int) -> UniquePermutations<Element>
    where R: RangeExpression, R.Bound == Int
}
```

### Documentation Plan
I've added API documentation on the new methods and type, and have updated `Permutations.md` to include information about unique permutations.

### Test Plan
I've created tests in the `UniquePermutationsTests.swift` file.

### Source Impact
None, additive only.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
