### PR TITLE
Internally add Collection.endOfPrefix(while:) and BidirectionalCollection.startOfSuffix(while:)

### DIFF
--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -76,8 +76,7 @@ extension LazyChunked: LazyCollectionProtocol {
   internal func endOfChunk(startingAt start: Base.Index) -> Base.Index {
     let subject = projection(base[start])
     return base[base.index(after: start)...]
-      .firstIndex(where: { !belongInSameGroup(subject, projection($0)) })
-      ?? base.endIndex
+      .endOfPrefix(while: { belongInSameGroup(subject, projection($0)) })
   }
   
   @inlinable
@@ -119,20 +118,8 @@ extension LazyChunked: BidirectionalCollection
     
     // Get the projected value of the last element in the range ending at `end`.
     let subject = projection(base[indexBeforeEnd])
-    
-    // Search backward from `end` for the first element whose projection isn't
-    // equal to `subject`.
-    if let firstMismatch = base[..<indexBeforeEnd]
-      .lastIndex(where: { !belongInSameGroup(projection($0), subject) })
-    {
-      // If we found one, that's the last element of the _next_ previous chunk,
-      // and therefore one position _before_ the start of this chunk.
-      return base.index(after: firstMismatch)
-    } else {
-      // If we didn't find such an element, this chunk extends back to the start
-      // of the collection.
-      return base.startIndex
-    }
+    return base[..<indexBeforeEnd]
+      .startOfSuffix(while: { belongInSameGroup(projection($0), subject) })
   }
 
   @inlinable

--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -37,3 +37,59 @@ extension BidirectionalCollection {
     return self[result...]
   }
 }
+
+//===----------------------------------------------------------------------===//
+// endOfPrefix(while:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns the exclusive upper bound of the prefix of elements that satisfy
+  /// the predicate.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the collection
+  ///   as its argument and returns `true` if the element is part of the prefix
+  ///   or `false` if it is not. Once the predicate returns `false` it will not
+  ///   be called again.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @usableFromInline
+  internal func endOfPrefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var index = startIndex
+    while try index != endIndex && predicate(self[index]) {
+      formIndex(after: &index)
+    }
+    return index
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// startOfSuffix(while:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+  /// Returns the inclusive lower bound of the suffix of elements that satisfy
+  /// the predicate.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the collection
+  ///   as its argument and returns `true` if the element is part of the suffix
+  ///   or `false` if it is not. Once the predicate returns `false` it will not
+  ///   be called again.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @usableFromInline
+  internal func startOfSuffix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var index = endIndex
+    while index != startIndex {
+      let after = index
+      formIndex(before: &index)
+      if try !predicate(self[index]) {
+        return after
+      }
+    }
+    return index
+  }
+}

--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -27,14 +27,7 @@ extension BidirectionalCollection {
   public func suffix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    let start = startIndex
-    var result = endIndex
-    while result != start {
-      let previous = index(before: result)
-      guard try predicate(self[previous]) else { break }
-      result = previous
-    }
-    return self[result...]
+    try self[startOfSuffix(while: predicate)...]
   }
 }
 

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -29,20 +29,8 @@ extension BidirectionalCollection {
   public func trimming(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    // Consume elements from the front.
-    let sliceStart = try firstIndex { try predicate($0) == false } ?? endIndex
-    // sliceEnd is the index _after_ the last index to match the predicate.
-    var sliceEnd = endIndex
-    
-    while sliceStart != sliceEnd {
-      let idxBeforeSliceEnd = index(before: sliceEnd)
-      guard try predicate(self[idxBeforeSliceEnd]) else {
-        return self[sliceStart..<sliceEnd]
-      }
-      sliceEnd = idxBeforeSliceEnd
-    }
-    
-    // Trimmed everything.
-    return self[Range(uncheckedBounds: (sliceStart, sliceStart))]
+    let start = try endOfPrefix(while: predicate)
+    let end = try self[start...].startOfSuffix(while: predicate)
+    return self[start..<end]
   }
 }

--- a/Tests/SwiftAlgorithmsTests/SuffixTests.swift
+++ b/Tests/SwiftAlgorithmsTests/SuffixTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 final class SuffixTests: XCTestCase {
   func testSuffix() {
@@ -22,5 +22,29 @@ final class SuffixTests: XCTestCase {
     
     let empty: [Int] = []
     XCTAssertEqualSequences(empty.suffix(while: { $0 > 10 }), [])
+  }
+  
+  func testEndOfPrefix() {
+    let array = Array(0..<10)
+    XCTAssertEqual(array.endOfPrefix(while: { $0 < 3 }), 3)
+    XCTAssertEqual(array.endOfPrefix(while: { _ in false }), array.startIndex)
+    XCTAssertEqual(array.endOfPrefix(while: { _ in true }), array.endIndex)
+    
+    let empty = [Int]()
+    XCTAssertEqual(empty.endOfPrefix(while: { $0 < 3 }), 0)
+    XCTAssertEqual(empty.endOfPrefix(while: { _ in false }), empty.startIndex)
+    XCTAssertEqual(empty.endOfPrefix(while: { _ in true }), empty.endIndex)
+  }
+  
+  func testStartOfSuffix() {
+    let array = Array(0..<10)
+    XCTAssertEqual(array.startOfSuffix(while: { $0 >= 3 }), 3)
+    XCTAssertEqual(array.startOfSuffix(while: { _ in false }), array.endIndex)
+    XCTAssertEqual(array.startOfSuffix(while: { _ in true }), array.startIndex)
+    
+    let empty = [Int]()
+    XCTAssertEqual(empty.startOfSuffix(while: { $0 < 3 }), 0)
+    XCTAssertEqual(empty.startOfSuffix(while: { _ in false }), empty.endIndex)
+    XCTAssertEqual(empty.startOfSuffix(while: { _ in true }), empty.startIndex)
   }
 }


### PR DESCRIPTION
Internally adds the `endOfPrefix(while:)` method to `Collection` and the `startOfSuffix(while:)` method to `BidirectionalCollection`.

These methods return the same values as `prefix(while: predicate).endIndex` and `suffix(while: predicate).startIndex`, respectively. We're adding them as internal methods for now because we're already using this functionality in several places throughout the package, but it's unclear whether these are the names we want to stick with.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
