### PR TITLE
Add a breadth-first search algorithm over any tree

### DIFF
--- a/Guides/BreadthFirstSearch.md
+++ b/Guides/BreadthFirstSearch.md
@@ -1,0 +1,55 @@
+# Breadth First Search
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/BreadthFirstSearch.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/BreadthFirstSearch.swift)]
+
+Traverses a tree structure in breadth-first order.
+
+This traversal can occur on any tree structure by using `BreadthFirstTreeSequence`:
+
+```swift
+let tree = Node(element: "1", children: [
+	Node(element: "2", children: [
+		Node(element: "5", children: [
+			Node(element: "9"),
+			Node(element: "10"),
+		]),
+		Node(element: "6"),
+	]),
+	Node(element: "3"),
+	Node(element: "4", children: [
+		Node(element: "7", children: [
+			Node(element: "11"),
+			Node(element: "12"),
+		]),
+		Node(element: "8"),
+	]),
+])
+
+let elements = BreadthFirstTreeSequence(root: tree, children: { $0.children })
+// Array(elements) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+```
+
+## Detailed Design
+
+The `BreadthFirstTreeSequence` initializer takes two arguments:
+
+  1. The root of the tree
+  2. A closure that, given a parent node, returns all of its immediate children
+
+`BreadthFirstTreeSequence` is a `Sequence`, which allows for use of functions like 
+`first(where:)`, `contains(where:)`, `map(_:)`, and others. The `Sequence` traverses
+lazily, meaning that it won’t traverse the tree further than it needs to in order to
+evaluate a function. For example, `first(where:)` can return before traversing the entire
+tree—an efficient breadth-first search. 
+
+### Naming
+
+The type’s name matches the common name of the algorithm.
+
+### Comparison with other languages
+
+**C++:** C++ Boost provides a `breadth_first_search` function that takes in a graph and a
+starting vertex.<sup>[1](https://www.boost.org/doc/libs/1_75_0/libs/graph/doc/breadth_first_search.html)</sup>
+
+**Rust:** petgraph offers a `Bfs` struct.<sup>[2](https://docs.rs/petgraph/0.4.10/petgraph/visit/struct.Bfs.html)</sup>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Other useful operations
 
+- [`BreadthFirstTreeSequence`](https://github.com/apple/swift-algorithms/blob/main/Guides/BreadthFirstSearch.md): Breadth-first ordering of a tree as a `Sequence`
 - [`chunked(by:)`, `chunked(on:)`, `chunks(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes or chunks of a given count.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`interspersed(with:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Intersperse.md): Place a value between every two elements of a sequence.

--- a/Sources/Algorithms/BreadthFirstSearch.swift
+++ b/Sources/Algorithms/BreadthFirstSearch.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A `Sequence` over a breadth-first traversal of a tree. It can be created
+/// from any type of element and a closure that returns the child elements,
+/// given a parent element.
+public struct BreadthFirstTreeSequence<T> {
+  /// The root of the tree, or `nil` if the tree is empty.
+  public let root: T?
+  
+  /// A closure that returns the child elements of an element in the tree
+  public let children: (T) -> [T]
+  
+  /// Initializes a generic breadth-first tree sequence with a given root and a
+  /// closure that can get the child elements in the sequence
+  /// - Parameters:
+  ///   - root: The first element in the sequence, or `nil` if the sequence is
+  ///   empty.
+  ///   - children: A closure that returns the children of an element in the
+  ///   tree
+  @inlinable
+  public init(root: T?, children: @escaping (T) -> [T]) {
+    self.root = root
+    self.children = children
+  }
+}
+
+extension BreadthFirstTreeSequence: Sequence {
+  /// An iterator over a `BreadthFirstTreeSequence` sequence.
+  public struct Iterator: IteratorProtocol {
+    /// The current level of elements currently being iterated through
+    // TODO: Use an index/iterator or a double-ended queue for performance
+    @usableFromInline
+    internal var elements: [T]
+    
+    /// The items that have already been iterated through but may have children
+    /// to iterate through later.
+    // TODO: Use an index/iterator or a double-ended queue for performance
+    @usableFromInline
+    internal var subsequentLevelElements: [T]
+    
+    /// A closure that returns the child elements of an element in the tree
+    @usableFromInline
+    internal var children: (T) -> [T]
+    
+    @inlinable
+    public mutating func next() -> T? {
+      // We iterate through `elements` first. If `elements` is empty, we pull
+      // the next (first) item in the `subsequentLevelElements` FIFO queue, get
+      // its children and iterate through those.
+      if let element = self.elements.first {
+        // We have elements in `elements`. Return the first one and remove it
+        // from the FIFO queue.
+        self.elements.removeFirst()
+        self.subsequentLevelElements.append(element)
+        return element
+      } else {
+        if let element = self.subsequentLevelElements.first {
+          // We don’t have any elements in `elements`. Grab the next element in
+          // `subsequentLevelElements` and move its children into `elements`.
+          self.subsequentLevelElements.removeFirst()
+          let children = self.children(element)
+          self.elements = children
+          return self.next()
+        } else {
+          // We don’t have any elements left in `elements` nor
+          // `subsequentLevelElements` to iterate through. We’re done iterating
+          // through the whole tree.
+          return nil
+        }
+      }
+    }
+    
+    @usableFromInline
+    internal init(root: T?, children: @escaping (T) -> [T]) {
+      if let element = root {
+        self.elements = [element]
+      } else {
+        self.elements = []
+      }
+      self.subsequentLevelElements = []
+      
+      self.children = children
+    }
+  }
+  
+  @inlinable
+  public func makeIterator() -> Iterator {
+    return Iterator(root: self.root, children: self.children)
+  }
+}
+
+extension BreadthFirstTreeSequence {
+  /// A Boolean value indicating whether the sequence is empty.
+  @inlinable
+  public var isEmpty: Bool {
+    return (self.root == nil)
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/BreadthFirstSearchTests.swift
+++ b/Tests/SwiftAlgorithmsTests/BreadthFirstSearchTests.swift
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import Algorithms
+
+final class BreadthFirstSearchTests: XCTestCase {
+	class Node {
+		let element: String
+		let children: [Node]
+		
+		init(element: String, children: [Node] = []) {
+			self.element = element
+			self.children = children
+		}
+	}
+	
+	/// Test an empty tree (no root)
+	func testEmpty() {
+		let s = BreadthFirstTreeSequence<Node>(root: nil, children: { $0.children })
+		let elements = s.map({ $0.element })
+		XCTAssertEqual(elements, [])
+	}
+	
+	/// Test searching a tree with only a root
+	func testRootOnly() {
+		let r = Node(element: "1")
+		
+		let s = BreadthFirstTreeSequence<Node>(root: r, children: { $0.children })
+		let elements = s.map({ $0.element })
+		XCTAssertEqual(elements, ["1"])
+	}
+	
+	/// Test searching a tree with two levels of depth
+	func testShallow() {
+		let r = Node(element: "1", children: [
+			Node(element: "1.1"),
+			Node(element: "1.2"),
+		])
+		
+		let s = BreadthFirstTreeSequence<Node>(root: r, children: { $0.children })
+		let elements = s.map({ $0.element })
+		XCTAssertEqual(elements, [
+			"1",
+			"1.1",
+			"1.2",
+		])
+	}
+	
+	/// Test searching a tree that varies from two to four levels of depth
+	func testBreadthFirstSearch() {
+		let r = Node(element: "1", children: [
+			Node(element: "1.1", children: [
+				Node(element: "1.1.1"),
+				Node(element: "1.1.2"),
+				Node(element: "1.1.3"),
+			]),
+			Node(element: "1.2", children: [
+				Node(element: "1.2.1"),
+				Node(element: "1.2.2"),
+			]),
+			Node(element: "1.3"),
+			Node(element: "1.4", children: [
+				Node(element: "1.4.1"),
+			]),
+			Node(element: "1.5", children: [
+				Node(element: "1.5.1"),
+				Node(element: "1.5.2", children: [
+					Node(element: "1.5.1.1"),
+					Node(element: "1.5.1.2"),
+					Node(element: "1.5.1.3"),
+				]),
+				Node(element: "1.5.3"),
+			]),
+		])
+		
+		let s = BreadthFirstTreeSequence(root: r, children: { $0.children })
+		let elements = s.map({ $0.element })
+		XCTAssertEqual(elements, [
+			"1",
+			"1.1",
+			"1.2",
+			"1.3",
+			"1.4",
+			"1.5",
+			"1.1.1",
+			"1.1.2",
+			"1.1.3",
+			"1.2.1",
+			"1.2.2",
+			"1.4.1",
+			"1.5.1",
+			"1.5.2",
+			"1.5.3",
+			"1.5.1.1",
+			"1.5.1.2",
+			"1.5.1.3",
+		])
+	}
+	
+	/// Test that when traversing the tree, we don’t traverse further than
+	/// necessary (e.g., when using `first(where:)`)
+	func testLaziness() {
+		let r = Node(element: "1", children: [
+			Node(element: "1.1", children: [
+				Node(element: "1.1.1"),
+				Node(element: "1.1.2"),
+				Node(element: "1.1.3"),
+			]),
+			Node(element: "1.2", children: [
+				Node(element: "1.2.1"),
+				Node(element: "1.2.2"),
+			]),
+			Node(element: "1.3"),
+			Node(element: "1.4", children: [
+				Node(element: "1.4.1"),
+			]),
+			Node(element: "1.5", children: [
+				Node(element: "1.5.1"),
+				Node(element: "1.5.2", children: [
+					Node(element: "1.5.1.1"),
+					Node(element: "1.5.1.2"),
+					Node(element: "1.5.1.3"),
+				]),
+				Node(element: "1.5.3"),
+			]),
+		])
+		
+		var count: Int = 0
+		let s = BreadthFirstTreeSequence(root: r, children: {
+			count += 1
+			return $0.children
+		})
+		
+		// Find the first element at the third level of depth in the tree.
+		let firstThirdLevelElement = s.first(where: {
+			$0.element.filter({ $0 != "." }).count > 2
+		})
+		
+		XCTAssertNotNil(firstThirdLevelElement)
+		XCTAssertEqual(firstThirdLevelElement!.element, "1.1.1")
+		// In order to get to this level of the tree, we only needed to call the
+		// closure twice:
+		//   1. To get the second level of items (from the root)
+		//   2. To get the first batch of third level of items (from the first
+		//      element at the second level)
+		XCTAssertEqual(count, 2)
+		
+		count = 0
+		// Find the fifth element at the third level of depth in the tree, which
+		// requires calling the closure 3 times.
+		let fifthThirdLevelElement = s.first(where: {
+			$0.element == "1.2.2"
+		})
+		XCTAssertNotNil(fifthThirdLevelElement)
+		XCTAssertEqual(fifthThirdLevelElement!.element, "1.2.2")
+		// In order to get to this level of the tree, we only needed to call the
+		// closure three times:
+		//   1. To get the second level of items (from the root)
+		//   2. To get the first batch of third level of items (from the first
+		//      element at the second level)
+		//   3. To get the second batch of third level of items (from the second
+		//      element at the second level)
+		XCTAssertEqual(count, 3)
+	}
+	
+	/// Test the example in the documentation
+	func testExample() {
+		let tree = Node(element: "1", children: [
+			Node(element: "2", children: [
+				Node(element: "5", children: [
+					Node(element: "9"),
+					Node(element: "10"),
+				]),
+				Node(element: "6"),
+			]),
+			Node(element: "3", children: [
+			]),
+			Node(element: "4", children: [
+				Node(element: "7", children: [
+					Node(element: "11"),
+					Node(element: "12"),
+				]),
+				Node(element: "8"),
+			]),
+		])
+		
+		let s = BreadthFirstTreeSequence(root: tree, children: { $0.children })
+		let elements = s.map({ $0.element })
+		XCTAssertEqual(elements, [
+			"1",
+			"2",
+			"3",
+			"4",
+			"5",
+			"6",
+			"7",
+			"8",
+			"9",
+			"10",
+			"11",
+			"12",
+		])
+	}
+}


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description
Adds a breadth-first search algorithm that can be applied to any tree structure. This is useful for traversing tree data structures that appear all over our apps, like the hierarchies for views, layers, view controllers, windows, and more.

### Detailed Design
Traverse a tree in breadth-first order by providing the root of the tree, and a closure that returns the children of a given node.

```swift
let tree = Node(element: 1, children: [
	Node(element: 2, children: [
		Node(element: 5, children: [
			Node(element: 9),
			Node(element: 10),
		]),
		Node(element: 6),
	]),
	Node(element: 3, children: [
	]),
	Node(element: 4, children: [
		Node(element: 7, children: [
			Node(element: 11),
			Node(element: 12),
		]),
		Node(element: 8),
	]),
])

let elements = BreadthFirstTreeSequence(root: tree, children: { $0.children })
// Array(elements) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
```

![Breadth-first-tree](https://upload.wikimedia.org/wikipedia/commons/3/33/Breadth-first-tree.svg)

### Open Questions
- [ ] **API Design and Future Considerations**
I’d like to consider how other tree traversal algorithms—namely depth-first search—would work and see how that may influence the API and implementation. Would there be shared code between the two?

- [ ] **Naming**
The majority of the additions in swift-algorithms are functions based on `Sequence`s and `Collection`s. Since there is no formal tree data structure in Swift, there isn’t really an existing structure to extend, thus the creation of a new structure. The structure represents a tree flattened into a sequence in breadth-first order. I think “breadth-first” should definitely be included in the name, although the term “search” doesn’t always apply. The sequence is great at searching, but it isn’t limited to that. You may want the breadth-first _ordering_ of something without necessarily searching for one element in particular.

- [ ] **Documentation**
I’d love to improve the documentation on how this works, particularly after the API settles down. I’m unsure how much depth to go into in how breadth-first search works as an algorithm versus assuming the reader is familiar with this well-known algorithm.

### Documentation Plan
- Added BreadthFirstSearch.md
- Added `BreadthFirstTreeSequence` to README.md
- Added inline documentation to implementation and unit tests

### Test Plan
Adds many unit tests for:
- Empty tree
- Simple tree
- Complex tree
- The number of times a closure is called during iteration of early termination algorithms, like `first(where:)`

### Source Impact
This is purely additive.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
