### PR TITLE
Add `trimmingSuffix`, `trimmingPrefix` and mutating variants

### DIFF
--- a/Guides/Trim.md
+++ b/Guides/Trim.md
@@ -48,6 +48,25 @@ func myAlgorithm2<Input>(input: Input) where Input: BidirectionalCollection {
 Swift provides the `BidirectionalCollection` protocol for marking types which support reverse traversal,
 and generic types and algorithms which want to make use of that should add it to their constraints.
 
+### >= 0.3.0
+
+In `v0.3.0` new methods are added to allow discarding all the elements matching the predicate at the beginning (prefix) or at the ending (suffix) of the collection.
+- `trimmingSuffix(while:)` can only be run on collections conforming to the `BidirectionalCollection` protocol.  
+- `trimmingPrefix(while:)` can be run also on collections conforming to the `Collection` protocol.
+
+```swift
+let myString = "   hello, world  "
+print(myString.trimmingPrefix(while: \.isWhitespace)) // "hello, world   "
+
+print(myString.trimmingSuffix(while: \.isWhitespace)) // "   hello, world"
+```
+Also mutating variants for all the methods already existing and the new ones are added.
+```swift
+var myString = "   hello, world  "
+myString.trim(while: \.isWhitespace)
+print(myString) // "hello, world"
+```
+
 ### Complexity
 
 Calling this method is O(_n_).

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -34,6 +34,15 @@ extension Collection {
   }
 }
 
+extension Collection where Self == SubSequence {
+  @inlinable
+  public mutating func trimPrefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimmingPrefix(while: predicate)
+  }
+}
+
 extension BidirectionalCollection {
   /// Returns a `SubSequence` formed by discarding all elements at the start and
   /// end of the collection which satisfy the given predicate.
@@ -78,5 +87,21 @@ extension BidirectionalCollection {
   ) rethrows -> SubSequence {
     let end = try self[startIndex...].startOfSuffix(while: predicate)
     return self[startIndex..<end]
+  }
+}
+
+extension BidirectionalCollection where Self == SubSequence {
+  @inlinable
+  public mutating func trim(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimming(while: predicate)
+  }
+  
+  @inlinable
+  public mutating func trimSuffix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimmingPrefix(while: predicate)
   }
 }

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -43,6 +43,7 @@ extension Collection {
 
 extension Collection where Self: RangeReplaceableCollection {
   @inlinable
+  @_disfavoredOverload
   public mutating func trimPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
@@ -117,6 +118,7 @@ extension BidirectionalCollection {
 
 extension BidirectionalCollection where Self: RangeReplaceableCollection {
   @inlinable
+  @_disfavoredOverload
   public mutating func trim(
     while predicate: (Element) throws -> Bool
   ) rethrows {
@@ -124,6 +126,7 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   }
   
   @inlinable
+  @_disfavoredOverload
   public mutating func trimSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows {

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -42,6 +42,22 @@ extension Collection {
 //===----------------------------------------------------------------------===//
 
 extension Collection where Self: RangeReplaceableCollection {
+  /// Mutates a `Collection` by discarding all elements at the start
+  /// of it which satisfy the given predicate.
+  ///
+  /// This example uses `trimPrefix(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trimPrefix(while: \.isWhitespace)
+  ///     print(myString) // "hello, world  "
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   @_disfavoredOverload
   public mutating func trimPrefix(
@@ -53,6 +69,22 @@ extension Collection where Self: RangeReplaceableCollection {
 }
 
 extension Collection where Self == Self.SubSequence {
+  /// Mutates a `Collection` by discarding all elements at the start
+  /// of it which satisfy the given predicate.
+  ///
+  /// This example uses `trimPrefix(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trimPrefix(while: \.isWhitespace)
+  ///     print(myString) // "hello, world  "
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   public mutating func trimPrefix(
     while predicate: (Element) throws -> Bool
@@ -117,6 +149,22 @@ extension BidirectionalCollection {
 //===----------------------------------------------------------------------===//
 
 extension BidirectionalCollection where Self: RangeReplaceableCollection {
+  /// Mutates a `BidirectionalCollection` by discarding all elements at the start
+  /// and at the end of it which satisfy the given predicate.
+  ///
+  /// This example uses `trim(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trim(while: \.isWhitespace)
+  ///     print(myString) // "hello, world"
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   @_disfavoredOverload
   public mutating func trim(
@@ -125,6 +173,22 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
     replaceSubrange(startIndex..<endIndex, with: try trimming(while: predicate))
   }
   
+  /// Mutates a `BidirectionalCollection` by discarding all elements at the end
+  /// of it which satisfy the given predicate.
+  ///
+  /// This example uses `trimSuffix(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trimSuffix(while: \.isWhitespace)
+  ///     print(myString) // "  hello, world"
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   @_disfavoredOverload
   public mutating func trimSuffix(
@@ -136,6 +200,22 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
 }
 
 extension BidirectionalCollection where Self == Self.SubSequence {
+  /// Mutates a `BidirectionalCollection` by discarding all elements at the start
+  /// and at the end of it which satisfy the given predicate.
+  ///
+  /// This example uses `trim(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trim(while: \.isWhitespace)
+  ///     print(myString) // "hello, world"
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   public mutating func trim(
     while predicate: (Element) throws -> Bool
@@ -143,6 +223,22 @@ extension BidirectionalCollection where Self == Self.SubSequence {
     self = try trimming(while: predicate)
   }
 
+  /// Mutates a `BidirectionalCollection` by discarding all elements at the end
+  /// of it which satisfy the given predicate.
+  ///
+  /// This example uses `trimSuffix(while:)` to remove the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     myString.trimSuffix(while: \.isWhitespace)
+  ///     print(myString) // "  hello, world"
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 removed from the string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
   @inlinable
   public mutating func trimSuffix(
     while predicate: (Element) throws -> Bool

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -9,6 +9,31 @@
 //
 //===----------------------------------------------------------------------===//
 
+extension Collection {
+  /// Returns a `SubSequence` formed by discarding all elements at the start
+  /// of the collection which satisfy the given predicate.
+  ///
+  /// This example uses `trimmingPrefix(while:)` to get a substring without the white
+  /// space at the beginning of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     print(myString.trimmingPrefix(while: \.isWhitespace)) // "hello, world  "
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 omitted from the resulting slice.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
+  @inlinable
+  public func trimmingPrefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    let start = try endOfPrefix(while: predicate)
+    return self[start..<endIndex]
+  }
+}
+
 extension BidirectionalCollection {
   /// Returns a `SubSequence` formed by discarding all elements at the start and
   /// end of the collection which satisfy the given predicate.
@@ -29,8 +54,29 @@ extension BidirectionalCollection {
   public func trimming(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    let start = try endOfPrefix(while: predicate)
-    let end = try self[start...].startOfSuffix(while: predicate)
-    return self[start..<end]
+    return try trimmingPrefix(while: predicate).trimmingSuffix(while: predicate)
+  }
+
+  /// Returns a `SubSequence` formed by discarding all elements at the end
+  /// of the collection which satisfy the given predicate.
+  ///
+  /// This example uses `trimmingSuffix(while:)` to get a substring without the white
+  /// space at the end of the string:
+  ///
+  ///     let myString = "  hello, world  "
+  ///     print(myString.trimmingSuffix(while: \.isWhitespace)) // "  hello, world"
+  ///
+  /// - Parameters:
+  ///    - predicate: A closure which determines if the element should be
+  ///                 omitted from the resulting slice.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  ///
+  @inlinable
+  public func trimmingSuffix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    let end = try self[startIndex...].startOfSuffix(while: predicate)
+    return self[startIndex..<end]
   }
 }

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -7,6 +7,9 @@
 //
 // See https://swift.org/LICENSE.txt for license information
 //
+
+//===----------------------------------------------------------------------===//
+// trimmingPrefix(while:)
 //===----------------------------------------------------------------------===//
 
 extension Collection {
@@ -34,14 +37,22 @@ extension Collection {
   }
 }
 
-extension Collection where Self == SubSequence {
+//===----------------------------------------------------------------------===//
+// trimPrefix(toStartAt:)
+//===----------------------------------------------------------------------===//
+
+extension Collection where Self: RangeReplaceableCollection {
   @inlinable
   public mutating func trimPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    self = try trimmingPrefix(while: predicate)
+    replaceSubrange(startIndex..<endIndex, with: try trimmingPrefix(while: predicate))
   }
 }
+
+//===----------------------------------------------------------------------===//
+// trimming(toStartAt:) / trimmingSuffix(while:)
+//===----------------------------------------------------------------------===//
 
 extension BidirectionalCollection {
   /// Returns a `SubSequence` formed by discarding all elements at the start and
@@ -90,18 +101,22 @@ extension BidirectionalCollection {
   }
 }
 
-extension BidirectionalCollection where Self == SubSequence {
+//===----------------------------------------------------------------------===//
+// trim(toStartAt:) / trimSuffix(while:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection where Self: RangeReplaceableCollection {
   @inlinable
   public mutating func trim(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    self = try trimming(while: predicate)
+    replaceSubrange(startIndex..<endIndex, with: try trimming(while: predicate))
   }
   
   @inlinable
   public mutating func trimSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    self = try trimmingPrefix(while: predicate)
+    replaceSubrange(startIndex..<endIndex, with: try trimmingSuffix(while: predicate))
   }
 }

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -51,6 +51,15 @@ extension Collection where Self: RangeReplaceableCollection {
   }
 }
 
+extension Collection where Self == Self.SubSequence {
+  @inlinable
+  public mutating func trimPrefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimmingPrefix(while: predicate)
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // trimming(while:) / trimmingSuffix(while:)
 //===----------------------------------------------------------------------===//
@@ -120,5 +129,21 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   ) rethrows {
     let start = try startOfSuffix(while: predicate)
     removeSubrange(start..<endIndex)
+  }
+}
+
+extension BidirectionalCollection where Self == Self.SubSequence {
+  @inlinable
+  public mutating func trim(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimming(while: predicate)
+  }
+
+  @inlinable
+  public mutating func trimSuffix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows {
+    self = try trimmingSuffix(while: predicate)
   }
 }

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -38,7 +38,7 @@ extension Collection {
 }
 
 //===----------------------------------------------------------------------===//
-// trimPrefix(toStartAt:)
+// trimPrefix(while:)
 //===----------------------------------------------------------------------===//
 
 extension Collection where Self: RangeReplaceableCollection {
@@ -46,12 +46,13 @@ extension Collection where Self: RangeReplaceableCollection {
   public mutating func trimPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    replaceSubrange(startIndex..<endIndex, with: try trimmingPrefix(while: predicate))
+    let end = try endOfPrefix(while: predicate)
+    removeSubrange(startIndex..<end)
   }
 }
 
 //===----------------------------------------------------------------------===//
-// trimming(toStartAt:) / trimmingSuffix(while:)
+// trimming(while:) / trimmingSuffix(while:)
 //===----------------------------------------------------------------------===//
 
 extension BidirectionalCollection {
@@ -76,7 +77,7 @@ extension BidirectionalCollection {
   ) rethrows -> SubSequence {
     return try trimmingPrefix(while: predicate).trimmingSuffix(while: predicate)
   }
-
+  
   /// Returns a `SubSequence` formed by discarding all elements at the end
   /// of the collection which satisfy the given predicate.
   ///
@@ -96,13 +97,13 @@ extension BidirectionalCollection {
   public func trimmingSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    let end = try self[startIndex...].startOfSuffix(while: predicate)
+    let end = try startOfSuffix(while: predicate)
     return self[startIndex..<end]
   }
 }
 
 //===----------------------------------------------------------------------===//
-// trim(toStartAt:) / trimSuffix(while:)
+// trim(while:) / trimSuffix(while:)
 //===----------------------------------------------------------------------===//
 
 extension BidirectionalCollection where Self: RangeReplaceableCollection {
@@ -117,6 +118,7 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   public mutating func trimSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    replaceSubrange(startIndex..<endIndex, with: try trimmingSuffix(while: predicate))
+    let start = try startOfSuffix(while: predicate)
+    removeSubrange(start..<endIndex)
   }
 }

--- a/Tests/SwiftAlgorithmsTests/TrimTests.swift
+++ b/Tests/SwiftAlgorithmsTests/TrimTests.swift
@@ -13,12 +13,12 @@ import Algorithms
 import XCTest
 
 final class TrimTests: XCTestCase {
-
+  
   func testEmpty() {
     let results_empty = ([] as [Int]).trimming { $0.isMultiple(of: 2) }
     XCTAssertEqual(results_empty, [])
   }
-
+  
   func testNoMatch() {
     // No match (nothing trimmed).
     let results_nomatch = [1, 3, 5, 7, 9, 11, 13, 15].trimming {
@@ -26,44 +26,83 @@ final class TrimTests: XCTestCase {
     }
     XCTAssertEqual(results_nomatch, [1, 3, 5, 7, 9, 11, 13, 15])
   }
-
+  
   func testNoTailMatch() {
     // No tail match (only trim head).
     let results_notailmatch = [1, 3, 5, 7, 9, 11, 13, 15].trimming { $0 < 10 }
     XCTAssertEqual(results_notailmatch, [11, 13, 15])
   }
-
+  
   func testNoHeadMatch() {
     // No head match (only trim tail).
     let results_noheadmatch = [1, 3, 5, 7, 9, 11, 13, 15].trimming { $0 > 10 }
     XCTAssertEqual(results_noheadmatch, [1, 3, 5, 7, 9])
   }
-
+  
   func testBothEndsMatch() {
     // Both ends match, some string of >1 elements do not (return that string).
     let results = [2, 10, 11, 15, 20, 21, 100].trimming { $0.isMultiple(of: 2) }
     XCTAssertEqual(results, [11, 15, 20, 21])
   }
-
+  
   func testEverythingMatches() {
     // Everything matches (trim everything).
     let results_allmatch = [1, 3, 5, 7, 9, 11, 13, 15].trimming { _ in true }
     XCTAssertEqual(results_allmatch, [])
   }
-
+  
   func testEverythingButOneMatches() {
     // Both ends match, one element does not (trim all except that element).
     let results_one = [2, 10, 12, 15, 20, 100].trimming { $0.isMultiple(of: 2) }
     XCTAssertEqual(results_one, [15])
   }
-    
+  
   func testTrimmingPrefix() {
     let results = [2, 10, 12, 15, 20, 100].trimmingPrefix { $0.isMultiple(of: 2) }
     XCTAssertEqual(results, [15, 20, 100])
   }
-
+  
   func testTrimmingSuffix() {
     let results = [2, 10, 12, 15, 20, 100].trimmingSuffix { $0.isMultiple(of: 2) }
     XCTAssertEqual(results, [2, 10, 12, 15])
+  }
+  
+  // Self == Self.Subsequence
+  func testTrimNoAmbiguity() {
+    var values = [2, 10, 12, 15, 20, 100] as ArraySlice
+    values.trim { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [15])
+  }
+  
+  // Self == Self.Subsequence
+  func testTrimPrefixNoAmbiguity() {
+    var values = [2, 10, 12, 15, 20, 100] as ArraySlice
+    values.trimPrefix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [15, 20, 100])
+  }
+  
+  // Self == Self.Subsequence
+  func testTrimSuffixNoAmbiguity() {
+    var values = [2, 10, 12, 15, 20, 100] as ArraySlice
+    values.trimSuffix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [2, 10, 12, 15])
+  }
+
+  func testTrimRangeReplaceable() {
+    var values = [2, 10, 12, 15, 20, 100]
+    values.trim { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [15])
+  }
+
+  func testTrimPrefixRangeReplaceable() {
+    var values = [2, 10, 12, 15, 20, 100]
+    values.trimPrefix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [15, 20, 100])
+  }
+
+  func testTrimSuffixRangeReplaceable() {
+    var values = [2, 10, 12, 15, 20, 100]
+    values.trimSuffix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(values, [2, 10, 12, 15])
   }
 }

--- a/Tests/SwiftAlgorithmsTests/TrimTests.swift
+++ b/Tests/SwiftAlgorithmsTests/TrimTests.swift
@@ -58,12 +58,12 @@ final class TrimTests: XCTestCase {
   }
     
   func testTrimmingPrefix() {
-      let results = [2, 10, 12, 15, 20, 100].trimmingPrefix { $0.isMultiple(of: 2) }
-      XCTAssertEqual(results, [15, 20, 100])
+    let results = [2, 10, 12, 15, 20, 100].trimmingPrefix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(results, [15, 20, 100])
   }
 
   func testTrimmingSuffix() {
-      let results = [2, 10, 12, 15, 20, 100].trimmingSuffix { $0.isMultiple(of: 2) }
-      XCTAssertEqual(results, [2, 10, 12, 15])
+    let results = [2, 10, 12, 15, 20, 100].trimmingSuffix { $0.isMultiple(of: 2) }
+    XCTAssertEqual(results, [2, 10, 12, 15])
   }
 }

--- a/Tests/SwiftAlgorithmsTests/TrimTests.swift
+++ b/Tests/SwiftAlgorithmsTests/TrimTests.swift
@@ -56,4 +56,14 @@ final class TrimTests: XCTestCase {
     let results_one = [2, 10, 12, 15, 20, 100].trimming { $0.isMultiple(of: 2) }
     XCTAssertEqual(results_one, [15])
   }
+    
+  func testTrimmingPrefix() {
+      let results = [2, 10, 12, 15, 20, 100].trimmingPrefix { $0.isMultiple(of: 2) }
+      XCTAssertEqual(results, [15, 20, 100])
+  }
+
+  func testTrimmingSuffix() {
+      let results = [2, 10, 12, 15, 20, 100].trimmingSuffix { $0.isMultiple(of: 2) }
+      XCTAssertEqual(results, [2, 10, 12, 15])
+  }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description
Closes #101 
`trimming(while:)` is split in two methods `trimmingPrefix(while:)` which is available to all `Collection`s and `trimmingSuffix(while:)` available only to `BidirectionalCollection`s.
This also adds a mutable variant of each `trim` method where `SubSequence == Self`.

### Detailed Design

```swift
func trimmingSuffix(
  while predicate: (Element) throws -> Bool
) rethrows -> SubSequence {
  let end = try self[startIndex...].startOfSuffix(while: predicate)
  return self[startIndex..<end]
}

func trimmingPrefix(
  while predicate: (Element) throws -> Bool
) rethrows -> SubSequence {
  let start = try endOfPrefix(while: predicate)
  return self[start..<endIndex]
}

func trimming(
  while predicate: (Element) throws -> Bool
) rethrows -> SubSequence {
  return try trimmingPrefix(while: predicate).trimmingSuffix(while: predicate)
}
```
The same applies to mutable `trim`s.
- [x] `String` must access mutable `trim`s

### Documentation Plan
Docs not yet updated.

### Test Plan
Since the two new methods are just a refactoring of `trimming` all those tests also apply to the new API.
- [x] Mutating variants tests added.

### Source Impact
It doesn't break anything.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
