### PR TITLE
Improve XCTAssertEqualSequences to log difference

### DIFF
--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -65,7 +65,8 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
 ) rethrows where S1.Element == S2.Element {
 
   func fail(_ reason: String) {
-    XCTFail(message().isEmpty ? reason : "\(message()) - \(reason)",
+    let message = message()
+    XCTFail(message.isEmpty ? reason : "\(message) - \(reason)",
             file: file, line: line)
   }
 

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -78,7 +78,7 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
       idx += 1
       continue
     case let (e1?, e2?):
-      fail("unequal elements at index \(idx) (\(e1) != \(e2))")
+      fail("element \(e1) on first sequence does not match element \(e2) on second sequence at position \(idx)")
     case (_?, nil):
       fail("second sequence shorter than first")
     case (nil, _?):

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -63,25 +63,30 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
   _ message: @autoclosure () -> String = "",
   file: StaticString = #file, line: UInt = #line
 ) rethrows where S1.Element == S2.Element {
-    var iter1 = try expression1().makeIterator()
-    var iter2 = try expression2().makeIterator()
-    while true {
-      switch (iter1.next(), iter2.next()) {
-      case let (e1?, e2?):
-        XCTAssertTrue(
-          areEquivalent(e1, e2),
-          "Element \(e1) in first sequence not equal to \(e2) in second sequence.",
-          file: file, line: line)
-        return
-      case (_?, nil):
-        XCTFail("Second sequence shorter than first")
-        return
-      case (nil, _?):
-        XCTFail("First sequence shorter than second")
-        return
-      case (nil, nil): return
-      }
+
+  func fail(_ reason: String) {
+    XCTFail(message().isEmpty ? reason : "\(message()) - \(reason)",
+            file: file, line: line)
+  }
+
+  var iter1 = try expression1().makeIterator()
+  var iter2 = try expression2().makeIterator()
+  var idx = 0
+  while true {
+    switch (iter1.next(), iter2.next()) {
+    case let (e1?, e2?) where areEquivalent(e1, e2):
+      idx += 1
+      continue
+    case let (e1?, e2?):
+      fail("unequal elements at index \(idx) (\(e1) != \(e2))")
+    case (_?, nil):
+      fail("second sequence shorter than first")
+    case (nil, _?):
+      fail("first sequence shorter than second")
+    case (nil, nil): break
     }
+    return
+  }
 }
 
 func XCTAssertLazySequence<S: LazySequenceProtocol>(_: S) {}


### PR DESCRIPTION
Implements improvement suggested @timvermeulen in #100

Improves the `XCTAssertEqualSequences` function to log when two elements in a sequence are not equivalent or when one of the sequences is shorter than the other.

I implemented it such that as soon as it finds to unequal elements between the sequences, it'll fail and stop without looking at the remaining elements. We could try to make it more sophisticated if that's the goal.

I'm not sure how to test it, since it's a test helper utility. As it stands, `XCTAssertEqualSequences` was not being tested. The test suite, which heavily depends on the function still passes after the changes but that doesn't exercise the function in the failure cases or its output. I experimented with that by changing some tests to make them fail and it seemed to work fine.

The code was based on the implementation of `elementsEqual` from the Swift standard library.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
