### PR TITLE
Add new `FiniteCycle` type as the return type of `Collection.cycled(times:)`

### DIFF
--- a/Guides/Cycle.md
+++ b/Guides/Cycle.md
@@ -16,8 +16,7 @@ for x in (1...3).cycled(times: 3) {
 // Prints 1 through 3 three times
 ```
 
-`cycled(times:)` combines two other existing standard library functions
-(`repeatElement` and `joined`) to provide a more expressive way of repeating a
+`cycled(times:)` provides a more expressive way of repeating a
 collection's elements a limited number of times.
 
 ## Detailed Design
@@ -38,7 +37,8 @@ conforms to `LazySequenceProtocol` when the base type conforms.
 
 Note that the returned `FiniteCycle` will always have `Collection`
 conformance, and will have `BidirectionalCollection` conformance
-when called on a bidirectional collection.
+when called on a bidirectional collection. `FiniteCycle` also
+conforms to `LazyCollectionProtocol` when the base type conforms.
 
 ### Complexity
 

--- a/Guides/Cycle.md
+++ b/Guides/Cycle.md
@@ -28,7 +28,7 @@ Two new methods are added to collections:
 extension Collection {
     func cycled() -> Cycle<Self>
 
-    func cycled(times: Int) -> FlattenSequence<Repeated<Self>>
+    func cycled(times: Int) -> FiniteCycle<Self>
 }
 ```
 
@@ -36,8 +36,8 @@ The new `Cycle` type is a sequence only, given that the `Collection` protocol
 design makes infinitely large types impossible/impractical. `Cycle` also
 conforms to `LazySequenceProtocol` when the base type conforms.
 
-Note that despite its name, the returned `FlattenSequence` will always have
-`Collection` conformance, and will have `BidirectionalCollection` conformance
+Note that the returned `FiniteCycle` will always have `Collection`
+conformance, and will have `BidirectionalCollection` conformance
 when called on a bidirectional collection.
 
 ### Complexity

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -110,7 +110,7 @@ extension FiniteCycle: Collection {
 
   @inlinable
   public subscript(_ index: Index) -> Element {
-    product[index.productIndex].element2
+    product[index.productIndex].1
   }
 
   @inlinable

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -56,6 +56,47 @@ extension Cycle: Sequence {
 
 extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 
+
+/// A collection wrapper that repeats the elements of a base collection for a finite number of times.
+public struct FiniteCycle<Base: Collection> {
+  /// The collection to repeat.
+  public let base: Base
+
+  /// The number of times to repeat the collection.
+  public let times: Int
+
+  @usableFromInline
+  internal init(base: Base, times: Int) {
+    self.base = base
+    self.times = times
+  }
+}
+
+extension FiniteCycle: Sequence {
+  /// The iterator for a `FiniteCycle` sequence.
+  public struct Iterator : IteratorProtocol {
+    @usableFromInline
+    var productIterator: Product2<Range<Int>, Base>.Iterator
+
+    @usableFromInline
+    internal init(_ product: Product2<Range<Int>, Base>) {
+      self.productIterator = product.makeIterator()
+    }
+
+    @inlinable
+    public mutating func next() -> Base.Element? {
+      self.productIterator.next()?.1
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    let iterations: Range<Int> = 0..<times
+    return Iterator(Product2(iterations, base))
+  }
+}
+
+extension FiniteCycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
+
 //===----------------------------------------------------------------------===//
 // cycled()
 //===----------------------------------------------------------------------===//

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -69,7 +69,7 @@ public struct FiniteCycle<Base: Collection> {
   }
 }
 
-extension FiniteCycle: Sequence {
+extension FiniteCycle {
   /// The iterator for a `FiniteCycle` sequence.
   public struct Iterator : IteratorProtocol {
     @usableFromInline
@@ -92,7 +92,8 @@ extension FiniteCycle: Sequence {
   }
 }
 
-extension FiniteCycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
+extension FiniteCycle: LazySequenceProtocol, LazyCollectionProtocol
+  where Base: LazyCollectionProtocol { }
 
 extension FiniteCycle: Collection {
 

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -57,7 +57,8 @@ extension Cycle: Sequence {
 extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 
 
-/// A collection wrapper that repeats the elements of a base collection for a finite number of times.
+/// A collection wrapper that repeats the elements of a base collection for a
+/// finite number of times.
 public struct FiniteCycle<Base: Collection> {
   /// The collection to repeat.
   public let base: Base

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -93,6 +93,53 @@ extension FiniteCycle: Sequence {
 
 extension FiniteCycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 
+extension FiniteCycle: Collection {
+
+  public typealias Index = Product2<Range<Int>, Base>.Index
+
+  public subscript(_ index: Index) -> Element {
+    product[index].element2
+  }
+
+  public var startIndex: Index {
+    product.startIndex
+  }
+
+  public var endIndex: Index {
+    product.endIndex
+  }
+
+  public func index(after i: Index) -> Index {
+    product.index(after: i)
+  }
+
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    product.index(i, offsetBy: distance)
+  }
+
+  public func index(
+    _ i: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    product.index(i, offsetBy: distance, limitedBy: limit)
+  }
+
+  public func distance(from start: Index, to end: Index) -> Int {
+    product.distance(from: start, to: end)
+  }
+}
+
+extension FiniteCycle: BidirectionalCollection
+  where Base: BidirectionalCollection {
+  public func index(before i: Index) -> Index {
+    product.index(before: i)
+  }
+}
+
+extension FiniteCycle: RandomAccessCollection
+  where Base: RandomAccessCollection { }
+
 //===----------------------------------------------------------------------===//
 // cycled()
 //===----------------------------------------------------------------------===//

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -153,7 +153,10 @@ extension FiniteCycle: BidirectionalCollection
 }
 
 extension FiniteCycle: RandomAccessCollection
-  where Base: RandomAccessCollection { }
+  where Base: RandomAccessCollection {}
+
+extension FiniteCycle: Equatable where Base: Equatable {}
+extension FiniteCycle: Hashable where Base: Hashable {}
 
 //===----------------------------------------------------------------------===//
 // cycled()

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -97,8 +97,8 @@ extension FiniteCycle: Collection {
 
   public typealias Index = Product2<Range<Int>, Base>.Index
 
-  public subscript(_ index: Index) -> Element {
-    product[index].element2
+  public var count: Int {
+    product.count
   }
 
   public var startIndex: Index {
@@ -109,8 +109,16 @@ extension FiniteCycle: Collection {
     product.endIndex
   }
 
+  public subscript(_ index: Index) -> Element {
+    product[index].element2
+  }
+
   public func index(after i: Index) -> Index {
     product.index(after: i)
+  }
+
+  public func distance(from start: Index, to end: Index) -> Int {
+    product.distance(from: start, to: end)
   }
 
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
@@ -123,10 +131,6 @@ extension FiniteCycle: Collection {
     limitedBy limit: Index
   ) -> Index? {
     product.index(i, offsetBy: distance, limitedBy: limit)
-  }
-
-  public func distance(from start: Index, to end: Index) -> Int {
-    product.distance(from: start, to: end)
   }
 }
 

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -61,10 +61,10 @@ extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 /// finite number of times.
 public struct FiniteCycle<Base: Collection> {
   /// The collection to repeat.
-  public let base: Base
+  internal let base: Base
 
   /// The number of times to repeat the collection.
-  public let times: Int
+  internal let times: Int
 
   @usableFromInline
   internal init(base: Base, times: Int) {

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -150,7 +150,7 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func cycled(times: Int) -> FlattenSequence<Repeated<Self>> {
-    repeatElement(self, count: times).joined()
+  public func cycled(times: Int) -> FiniteCycle<Self> {
+    FiniteCycle(base: self, times: times)
   }
 }

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -61,7 +61,8 @@ extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 /// finite number of times.
 public struct FiniteCycle<Base: Collection> {
   /// A Product2 instance for iterating the Base collection.
-  public let product: Product2<Range<Int>, Base>
+  @usableFromInline
+  internal let product: Product2<Range<Int>, Base>
 
   @inlinable
   internal init(base: Base, times: Int) {

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -85,7 +85,7 @@ extension FiniteCycle: Sequence {
 
     @inlinable
     public mutating func next() -> Base.Element? {
-      self.productIterator.next()?.1
+      self.productIterator.next()?.element2
     }
   }
 

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -63,7 +63,7 @@ public struct FiniteCycle<Base: Collection> {
   /// A Product2 instance for iterating the Base collection.
   public let product: Product2<Range<Int>, Base>
 
-  @usableFromInline
+  @inlinable
   internal init(base: Base, times: Int) {
     self.product = Product2(0..<times, base)
   }
@@ -75,7 +75,7 @@ extension FiniteCycle {
     @usableFromInline
     var productIterator: Product2<Range<Int>, Base>.Iterator
 
-    @usableFromInline
+    @inlinable
     internal init(product: Product2<Range<Int>, Base>) {
       self.productIterator = product.makeIterator()
     }

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -60,16 +60,12 @@ extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 /// A collection wrapper that repeats the elements of a base collection for a
 /// finite number of times.
 public struct FiniteCycle<Base: Collection> {
-  /// The collection to repeat.
-  internal let base: Base
-
-  /// The number of times to repeat the collection.
-  internal let times: Int
+  /// A Product2 instance for iterating the Base collection.
+  internal let product: Product2<Range<Int>, Base>
 
   @usableFromInline
   internal init(base: Base, times: Int) {
-    self.base = base
-    self.times = times
+    self.product = Product2(0..<times, base)
   }
 }
 
@@ -80,7 +76,7 @@ extension FiniteCycle: Sequence {
     var productIterator: Product2<Range<Int>, Base>.Iterator
 
     @usableFromInline
-    internal init(_ product: Product2<Range<Int>, Base>) {
+    internal init(product: Product2<Range<Int>, Base>) {
       self.productIterator = product.makeIterator()
     }
 
@@ -91,8 +87,7 @@ extension FiniteCycle: Sequence {
   }
 
   public func makeIterator() -> Iterator {
-    let iterations: Range<Int> = 0..<times
-    return Iterator(Product2(iterations, base))
+    return Iterator(product: product)
   }
 }
 

--- a/Sources/Algorithms/Cycle.swift
+++ b/Sources/Algorithms/Cycle.swift
@@ -61,7 +61,7 @@ extension Cycle: LazySequenceProtocol where Base: LazySequenceProtocol {}
 /// finite number of times.
 public struct FiniteCycle<Base: Collection> {
   /// A Product2 instance for iterating the Base collection.
-  internal let product: Product2<Range<Int>, Base>
+  public let product: Product2<Range<Int>, Base>
 
   @usableFromInline
   internal init(base: Base, times: Int) {
@@ -86,6 +86,7 @@ extension FiniteCycle: Sequence {
     }
   }
 
+  @inlinable
   public func makeIterator() -> Iterator {
     return Iterator(product: product)
   }
@@ -97,34 +98,42 @@ extension FiniteCycle: Collection {
 
   public typealias Index = Product2<Range<Int>, Base>.Index
 
+  @inlinable
   public var count: Int {
     product.count
   }
 
+  @inlinable
   public var startIndex: Index {
     product.startIndex
   }
 
+  @inlinable
   public var endIndex: Index {
     product.endIndex
   }
 
+  @inlinable
   public subscript(_ index: Index) -> Element {
     product[index].element2
   }
 
+  @inlinable
   public func index(after i: Index) -> Index {
     product.index(after: i)
   }
 
+  @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     product.distance(from: start, to: end)
   }
 
+  @inlinable
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     product.index(i, offsetBy: distance)
   }
 
+  @inlinable
   public func index(
     _ i: Index,
     offsetBy distance: Int,
@@ -136,6 +145,7 @@ extension FiniteCycle: Collection {
 
 extension FiniteCycle: BidirectionalCollection
   where Base: BidirectionalCollection {
+  @inlinable
   public func index(before i: Index) -> Index {
     product.index(before: i)
   }

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -44,7 +44,7 @@ extension Product2: Sequence {
     }
     
     @inlinable
-    public mutating func next() -> (Base1.Element, Base2.Element)? {
+    public mutating func next() -> (element1: Base1.Element, element2: Base2.Element)? {
       // This is the initial state, where i1.next() has never
       // been called, or the final state, where i1.next() has
       // already returned nil.
@@ -57,7 +57,7 @@ extension Product2: Sequence {
       // Get the next element from the second sequence, if not
       // at end.
       if let element2 = i2.next() {
-        return (element1!, element2)
+        return (element1: element1!, element2: element2)
       }
       
       // We've reached the end of the second sequence, so:
@@ -70,7 +70,7 @@ extension Product2: Sequence {
       
       i2 = base2.makeIterator()
       if let element2 = i2.next() {
-        return (element1, element2)
+        return (element1: element1, element2: element2)
       } else {
         return nil
       }
@@ -121,8 +121,8 @@ extension Product2: Collection where Base1: Collection {
   }
   
   @inlinable
-  public subscript(position: Index) -> (Base1.Element, Base2.Element) {
-    (base1[position.i1], base2[position.i2])
+  public subscript(position: Index) -> (element1: Base1.Element, element2: Base2.Element) {
+    (element1: base1[position.i1], element2: base2[position.i2])
   }
   
   /// Forms an index from a pair of base indices, normalizing

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -44,8 +44,8 @@ extension Product2: Sequence {
     }
     
     @inlinable
-    public mutating func next() -> (element1: Base1.Element,
-                                    element2: Base2.Element)? {
+    public mutating func next() -> (Base1.Element,
+                                    Base2.Element)? {
       // This is the initial state, where i1.next() has never
       // been called, or the final state, where i1.next() has
       // already returned nil.
@@ -58,7 +58,7 @@ extension Product2: Sequence {
       // Get the next element from the second sequence, if not
       // at end.
       if let element2 = i2.next() {
-        return (element1: element1!, element2: element2)
+        return (element1!, element2)
       }
       
       // We've reached the end of the second sequence, so:
@@ -71,7 +71,7 @@ extension Product2: Sequence {
       
       i2 = base2.makeIterator()
       if let element2 = i2.next() {
-        return (element1: element1, element2: element2)
+        return (element1, element2)
       } else {
         return nil
       }
@@ -122,9 +122,9 @@ extension Product2: Collection where Base1: Collection {
   }
   
   @inlinable
-  public subscript(position: Index) -> (element1: Base1.Element,
-                                        element2: Base2.Element) {
-    (element1: base1[position.i1], element2: base2[position.i2])
+  public subscript(position: Index) -> (Base1.Element,
+                                        Base2.Element) {
+    (base1[position.i1], base2[position.i2])
   }
   
   /// Forms an index from a pair of base indices, normalizing

--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -44,7 +44,8 @@ extension Product2: Sequence {
     }
     
     @inlinable
-    public mutating func next() -> (element1: Base1.Element, element2: Base2.Element)? {
+    public mutating func next() -> (element1: Base1.Element,
+                                    element2: Base2.Element)? {
       // This is the initial state, where i1.next() has never
       // been called, or the final state, where i1.next() has
       // already returned nil.
@@ -121,7 +122,8 @@ extension Product2: Collection where Base1: Collection {
   }
   
   @inlinable
-  public subscript(position: Index) -> (element1: Base1.Element, element2: Base2.Element) {
+  public subscript(position: Index) -> (element1: Base1.Element,
+                                        element2: Base2.Element) {
     (element1: base1[position.i1], element2: base2[position.i2])
   }
   

--- a/Tests/SwiftAlgorithmsTests/CycleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CycleTests.swift
@@ -80,4 +80,9 @@ final class CycleTests: XCTestCase {
     let previousIndex = cycle.index(before: nextIndex)
     XCTAssertEqual(cycle.distance(from: startIndex, to: previousIndex), 7)
   }
+
+  func testRepeatedCount() {
+    let cycle = (1..<5).cycled(times: 2)
+    XCTAssertEqual(cycle.count, 8)
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/CycleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CycleTests.swift
@@ -19,28 +19,45 @@ final class CycleTests: XCTestCase {
       [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
       cycle.prefix(20)
     )
+  }
 
+  func testCycleClosedRangePrefix() {
     let a = Array((0..<17).cycled().prefix(10_000))
     XCTAssertEqual(10_000, a.count)
-    
+  }
+
+  func testEmptyCycle() {
     let empty = Array("".cycled())
     XCTAssert(empty.isEmpty)
   }
-  
+
+  func testCycleLazy() {
+    XCTAssertLazySequence((1...4).lazy.cycled())
+  }
+
   func testRepeated() {
     let repeats = (1...4).cycled(times: 3)
     XCTAssertEqualSequences(
       [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
       repeats)
-    
+  }
+
+  func testRepeatedClosedRange() {
+    let repeats = Array((1..<5).cycled(times: 2500))
+    XCTAssertEqual(10_000, repeats.count)
+  }
+
+  func testRepeatedEmptyCollection() {
     let empty1 = Array("".cycled(times: 100))
     XCTAssert(empty1.isEmpty)
-    
+  }
+
+  func testRepeatedZeroTimesCycle() {
     let empty2 = Array("Hello".cycled(times: 0))
     XCTAssert(empty2.isEmpty)
   }
-  
-  func testCycleLazy() {
-    XCTAssertLazySequence((1...4).lazy.cycled())
+
+  func testRepeatedLazy() {
+    XCTAssertLazySequence((1...4).lazy.cycled(times: 3))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/CycleTests.swift
+++ b/Tests/SwiftAlgorithmsTests/CycleTests.swift
@@ -60,4 +60,24 @@ final class CycleTests: XCTestCase {
   func testRepeatedLazy() {
     XCTAssertLazySequence((1...4).lazy.cycled(times: 3))
   }
+
+  func testRepeatedIndexMethods() {
+    let cycle = (1..<5).cycled(times: 2)
+    let startIndex = cycle.startIndex
+    var nextIndex = cycle.index(after: startIndex)
+    XCTAssertEqual(cycle.distance(from: startIndex, to: nextIndex), 1)
+
+    nextIndex = cycle.index(nextIndex, offsetBy: 5)
+    XCTAssertEqual(cycle.distance(from: startIndex, to: nextIndex), 6)
+
+    nextIndex = cycle.index(nextIndex, offsetBy: 2, limitedBy: cycle.endIndex)!
+    XCTAssertEqual(cycle.distance(from: startIndex, to: nextIndex), 8)
+
+    let outOfBounds = cycle.index(nextIndex, offsetBy: 1,
+                                  limitedBy: cycle.endIndex)
+    XCTAssertNil(outOfBounds)
+
+    let previousIndex = cycle.index(before: nextIndex)
+    XCTAssertEqual(cycle.distance(from: startIndex, to: previousIndex), 7)
+  }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR aims to fix #99. I have also split up some relevant tests into separate methods for empty collections and changed some tests for `FiniteCycle`. I have also added tuple labels to `Product2` when using the `Iterator.next()` method and also in the `subscript` method. This is a cosmetic improvement, but I felt it may read better.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
