### PR TITLE
Remove the inout on reductions(into:_:) to be consistent with the stdlib reduce(into:_)

### DIFF
--- a/Guides/Reductions.md
+++ b/Guides/Reductions.md
@@ -12,12 +12,9 @@ let exclusiveRunningTotal = (1...5).reductions(0, +)
 print(exclusiveRunningTotal)
 // prints [0, 1, 3, 6, 10, 15]
 
-var value = 0
-let intoRunningTotal = (1...5).reductions(into: &value, +=)
+let intoRunningTotal = (1...5).reductions(into: 0, +=)
 print(intoRunningTotal)
 // prints [0, 1, 3, 6, 10, 15]
-print(value)
-// prints 15
 
 let inclusiveRunningTotal = (1...5).reductions(+)
 print(inclusiveRunningTotal)
@@ -38,7 +35,7 @@ extension LazySequenceProtocol {
   ) -> ExclusiveReductions<Result, Self>
 
   public func reductions<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: @escaping (inout Result, Element) -> Void
   ) -> ExclusiveReductions<Result, Self>
 
@@ -57,7 +54,7 @@ extension Sequence {
   ) rethrows -> [Result]
 
   public func reductions<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: (inout Result, Element) throws -> Void
   ) rethrows -> [Result]
 

--- a/Sources/Algorithms/Reductions.swift
+++ b/Sources/Algorithms/Reductions.swift
@@ -39,9 +39,7 @@ extension LazySequenceProtocol {
     _ initial: Result,
     _ transform: @escaping (Result, Element) -> Result
   ) -> ExclusiveReductions<Result, Self> {
-
-    var result = initial
-    return reductions(into: &result) { result, element in
+    return reductions(into: initial) { result, element in
       result = transform(result, element)
     }
   }
@@ -69,7 +67,7 @@ extension LazySequenceProtocol {
   /// - Complexity: O(1)
   @inlinable
   public func reductions<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: @escaping (inout Result, Element) -> Void
   ) -> ExclusiveReductions<Result, Self> {
     ExclusiveReductions(base: self, initial: initial, transform: transform)
@@ -117,9 +115,7 @@ extension Sequence {
     _ initial: Result,
     _ transform: (Result, Element) throws -> Result
   ) rethrows -> [Result] {
-
-    var result = initial
-    return try reductions(into: &result) { result, element in
+    return try reductions(into: initial) { result, element in
       result = try transform(result, element)
     }
   }
@@ -160,7 +156,7 @@ extension Sequence {
   /// - Complexity: O(_n_), where _n_ is the length of the sequence.
   @inlinable
   public func reductions<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: (inout Result, Element) throws -> Void
   ) rethrows -> [Result] {
 
@@ -168,6 +164,7 @@ extension Sequence {
     output.reserveCapacity(underestimatedCount + 1)
     output.append(initial)
 
+    var initial = initial
     for element in self {
       try transform(&initial, element)
       output.append(initial)
@@ -595,10 +592,10 @@ extension LazySequenceProtocol {
   @available(*, deprecated, message: "Use reductions(into:_:) instead.")
   @inlinable
   public func scan<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: @escaping (inout Result, Element) -> Void
   ) -> ExclusiveReductions<Result, Self> {
-    reductions(into: &initial, transform)
+    reductions(into: initial, transform)
   }
 }
 
@@ -616,10 +613,10 @@ extension Sequence {
   @available(*, deprecated, message: "Use reductions(into:_:) instead.")
   @inlinable
   public func scan<Result>(
-    into initial: inout Result,
+    into initial: Result,
     _ transform: (inout Result, Element) throws -> Void
   ) rethrows -> [Result] {
-    try reductions(into: &initial, transform)
+    try reductions(into: initial, transform)
   }
 }
 

--- a/Tests/SwiftAlgorithmsTests/ReductionsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ReductionsTests.swift
@@ -27,17 +27,11 @@ final class ReductionsTests: XCTestCase {
     XCTAssertEqualCollections([1].lazy.reductions(0, +), [0, 1])
     XCTAssertEqualCollections(EmptyCollection<Int>().lazy.reductions(0, +), [0])
 
-    var value = 0
-    XCTAssertEqual([1, 2, 3, 4].lazy.reductions(into: &value, +=), [0, 1, 3, 6, 10])
-    XCTAssertEqual(value, 10)
+    XCTAssertEqual([1, 2, 3, 4].lazy.reductions(into: 0, +=), [0, 1, 3, 6, 10])
 
-    value = 0
-    XCTAssertEqual([1].lazy.reductions(into: &value, +=), [0, 1])
-    XCTAssertEqual(value, 1)
+    XCTAssertEqual([1].lazy.reductions(into: 0, +=), [0, 1])
 
-    value = 0
-    XCTAssertEqual(EmptyCollection<Int>().lazy.reductions(into: &value, +=), [0])
-    XCTAssertEqual(value, 0)
+    XCTAssertEqual(EmptyCollection<Int>().lazy.reductions(into: 0, +=), [0])
 
     XCTAssertLazySequence((1...).prefix(1).lazy.reductions(0, +))
     XCTAssertLazySequence([1].lazy.reductions(0, +))
@@ -49,17 +43,11 @@ final class ReductionsTests: XCTestCase {
     XCTAssertEqual([1].reductions(0, +), [0, 1])
     XCTAssertEqual(EmptyCollection<Int>().reductions(0, +), [0])
 
-    var value = 0
-    XCTAssertEqual([1, 2, 3, 4].reductions(into: &value, +=), [0, 1, 3, 6, 10])
-    XCTAssertEqual(value, 10)
+    XCTAssertEqual([1, 2, 3, 4].reductions(into: 0, +=), [0, 1, 3, 6, 10])
 
-    value = 0
-    XCTAssertEqual([1].reductions(into: &value, +=), [0, 1])
-    XCTAssertEqual(value, 1)
+    XCTAssertEqual([1].reductions(into: 0, +=), [0, 1])
 
-    value = 0
-    XCTAssertEqual(EmptyCollection<Int>().reductions(into: &value, +=), [0])
-    XCTAssertEqual(value, 0)
+    XCTAssertEqual(EmptyCollection<Int>().reductions(into: 0, +=), [0])
 
     XCTAssertNoThrow(try [].reductions(0) { _, _ in throw TestError() })
     XCTAssertThrowsError(try [1].reductions(0) { _, _ in throw TestError() })


### PR DESCRIPTION
### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
