### PR TITLE
Introduce `adjacentPairs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ package updates, you can specify your package dependency using
 
 ## [Unreleased]
 
-*No changes yet.*
+-`adjacentPairs()` lazily iterates over tuples of adjacent elements of a sequence.
 
 ---
 

--- a/Guides/AdjacentPairs.md
+++ b/Guides/AdjacentPairs.md
@@ -15,17 +15,21 @@ let pairs = numbers.adjacentPairs()
 
 ## Detailed Design
 
-The `adjacentPairs()` method is declared as a `Sequence` extension returning `AdjacentPairs`.
+The `adjacentPairs()` method is declared as a `Sequence` extension returning `AdjacentPairsSequence` and as a `Collection` extension returning `AdjacentPairsCollection`.
 
 ```swift
 extension Sequence {
-  public func adjacentPairs() -> AdjacentPairs<Self>
+  public func adjacentPairs() -> AdjacentPairsSequence<Self>
 }
 ```
 
-The resulting `AdjacentPairs` type is a sequence, with conditional conformance to `Collection`, `BidirectionalCollection`, and `RandomAccessCollection` when the underlying sequence conforms.
+```swift
+extension Collection {
+  public func adjacentPairs() -> AdjacentPairsCollection<Self>
+}
+```
 
-The spelling `zip(s, s.dropFirst())` for a sequence `s` is an equivalent operation on collection types; however, this implementation is undefined behavior on single-pass sequences, and `Zip2Sequence` does not conditionally conform to the `Collection` family of protocols.
+The `AdjacentPairsSequence` type is a sequence, and the `AdjacentPairsCollection` type is a collection with conditional conformance to `BidirectionalCollection` and `RandomAccessCollection` when the underlying collection conforms.
 
 ### Complexity
 
@@ -44,3 +48,5 @@ This function is often written as a `zip` of a sequence together with itself, mi
 **Haskell:** This operation is spelled ``s `zip` tail s``.
 
 **Python:** Python users may write `zip(s, s[1:])` for a list with at least one element. For natural language processing, the `nltk` package offers a `bigrams` function akin to this method.
+
+ Note that in Swift, the spelling `zip(s, s.dropFirst())` is undefined behavior for a single-pass sequence `s`.

--- a/Guides/AdjacentPairs.md
+++ b/Guides/AdjacentPairs.md
@@ -1,0 +1,46 @@
+# AdjacentPairs
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/AdjacentPairs.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift)]
+ 
+Lazily iterates over tuples of adjacent elements.
+
+This operation is available for any sequence by calling the `adjacentPairs()` method.
+
+```swift
+let numbers = (1...5)
+let pairs = numbers.adjacentPairs()
+// Array(pairs) == [(1, 2), (2, 3), (3, 4), (4, 5)]
+```
+
+## Detailed Design
+
+The `adjacentPairs()` method is declared as a `Sequence` extension returning `AdjacentPairs`.
+
+```swift
+extension Sequence {
+  public func adjacentPairs() -> AdjacentPairs<Self>
+}
+```
+
+The resulting `AdjacentPairs` type is a sequence, with conditional conformance to `Collection`, `BidirectionalCollection`, and `RandomAccessCollection` when the underlying sequence conforms.
+
+The spelling `zip(s, s.dropFirst())` for a sequence `s` is an equivalent operation on collection types; however, this implementation is undefined behavior on single-pass sequences, and `Zip2Sequence` does not conditionally conform to the `Collection` family of protocols.
+
+### Complexity
+
+Calling `adjacentPairs` is an O(1) operation.
+
+### Naming
+
+This method is named for clarity while remaining agnostic to any particular domain of programming. In natural language processing, this operation is akin to computing a list of bigrams; however, this algorithm is not specific to this use case.
+
+[naming]: https://forums.swift.org/t/naming-of-chained-with/40999/
+
+### Comparison with other languages
+
+This function is often written as a `zip` of a sequence together with itself, minus its first element.
+
+**Haskell:** This operation is spelled ``s `zip` tail s``.
+
+**Python:** Python users may write `zip(s, s[1:])` for a list with at least one element. For natural language processing, the `nltk` package offers a `bigrams` function akin to this method.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 
 #### Other useful operations
 
+- [`adjacentPairs()`](https://github.com/apple/swift-algorithms/blob/main/Guides/AdjacentPairs.md): Lazily iterates over tuples of adjacent elements.
 - [`chunked(by:)`, `chunked(on:)`, `chunks(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes or chunks of a given count.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`interspersed(with:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Intersperse.md): Place a value between every two elements of a sequence.

--- a/Sources/Algorithms/AdjacentPairs.swift
+++ b/Sources/Algorithms/AdjacentPairs.swift
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Creates a sequence of adjacent pairs of elements from this sequence.
+  ///
+  /// In the `AdjacentPairs` instance returned by this method, the elements of
+  /// the *i*th pair are the *i*th and *(i+1)*th elements of the underlying
+  /// sequence.
+  /// The following example uses the `adjacentPairs()` method to iterate over
+  /// adjacent pairs of integers:
+  ///
+  ///    for pair in (1...5).adjacentPairs() {
+  ///        print(pair)
+  ///    }
+  ///    // Prints "(1, 2)"
+  ///    // Prints "(2, 3)"
+  ///    // Prints "(3, 4)"
+  ///    // Prints "(4, 5)"
+  public func adjacentPairs() -> AdjacentPairs<Self> {
+    AdjacentPairs(_base: self)
+  }
+}
+
+/// A sequence of adjacent pairs of elements built from an underlying sequence.
+///
+/// In an `AdjacentPairs` sequence, the elements of the *i*th pair are the *i*th
+/// and *(i+1)*th elements of the underlying sequence. The following example
+/// uses the `adjacentPairs()` method to iterate over adjacent pairs of
+/// integers:
+/// ```
+/// for pair in (1...5).adjacentPairs() {
+///     print(pair)
+/// }
+/// // Prints "(1, 2)"
+/// // Prints "(2, 3)"
+/// // Prints "(3, 4)"
+/// // Prints "(4, 5)"
+/// ```
+public struct AdjacentPairs<Base: Sequence> {
+  internal let _base: Base
+
+  /// Creates an instance that makes pairs of adjacent elements from `base`.
+  internal init(_base: Base) {
+    self._base = _base
+  }
+}
+
+// MARK: - Sequence
+
+extension AdjacentPairs {
+  public struct Iterator {
+    internal var _base: Base.Iterator
+    internal var _previousElement: Base.Element?
+
+    internal init(_base: Base.Iterator) {
+      self._base = _base
+      self._previousElement = self._base.next()
+    }
+  }
+}
+
+extension AdjacentPairs.Iterator: IteratorProtocol {
+  public typealias Element = (Base.Element, Base.Element)
+
+  public mutating func next() -> Element? {
+    guard let previous = _previousElement, let next = _base.next() else {
+      return nil
+    }
+    _previousElement = next
+    return (previous, next)
+  }
+}
+
+extension AdjacentPairs: Sequence {
+  public func makeIterator() -> Iterator {
+    Iterator(_base: _base.makeIterator())
+  }
+
+  public var underestimatedCount: Int {
+    Swift.max(0, _base.underestimatedCount - 1)
+  }
+}
+
+// MARK: - Collection
+
+extension AdjacentPairs where Base: Collection {
+  public struct Index: Comparable {
+    internal var _base: Base.Index
+
+    internal init(_base: Base.Index) {
+      self._base = _base
+    }
+
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      lhs._base < rhs._base
+    }
+  }
+}
+
+extension AdjacentPairs: Collection where Base: Collection {
+  public var startIndex: Index { Index(_base: _base.startIndex) }
+
+  public var endIndex: Index {
+    switch _base.endIndex {
+    case _base.startIndex, _base.index(after: _base.startIndex):
+      return Index(_base: _base.startIndex)
+    case let endIndex:
+      return Index(_base: endIndex)
+    }
+  }
+
+  public subscript(position: Index) -> (Base.Element, Base.Element) {
+    (_base[position._base], _base[_base.index(after: position._base)])
+  }
+
+  public func index(after i: Index) -> Index {
+    let next = _base.index(after: i._base)
+    return _base.index(after: next) == _base.endIndex
+      ? endIndex
+      : Index(_base: next)
+  }
+
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    if distance == 0 {
+      return i
+    } else if distance > 0 {
+      let offsetIndex = _base.index(i._base, offsetBy: distance)
+      return _base.index(after: offsetIndex) == _base.endIndex
+        ? endIndex
+        : Index(_base: offsetIndex)
+    } else {
+      return i == endIndex
+        ? Index(_base: _base.index(i._base, offsetBy: distance - 1))
+        : Index(_base: _base.index(i._base, offsetBy: distance))
+    }
+  }
+
+  public func distance(from start: Index, to end: Index) -> Int {
+    let offset: Int
+    switch (start._base, end._base) {
+    case (_base.endIndex, _base.endIndex):
+      return 0
+    case (_base.endIndex, _):
+      offset = +1
+    case (_, _base.endIndex):
+      offset = -1
+    default:
+      offset = 0
+    }
+
+    return _base.distance(from: start._base, to: end._base) + offset
+  }
+
+  public var count: Int {
+    Swift.max(0, _base.count - 1)
+  }
+}
+
+extension AdjacentPairs: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  public func index(before i: Index) -> Index {
+    i == endIndex
+      ? Index(_base: _base.index(i._base, offsetBy: -2))
+      : Index(_base: _base.index(before: i._base))
+  }
+}
+
+extension AdjacentPairs: RandomAccessCollection
+  where Base: RandomAccessCollection {}

--- a/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class AdjacentPairsTests: XCTestCase {
+  func testZeroElements() {
+    let pairs = (0..<0).adjacentPairs()
+    XCTAssertEqual(pairs.startIndex, pairs.endIndex)
+    XCTAssert(Array(pairs) == [])
+  }
+
+  func testOneElement() {
+    let pairs = (0..<1).adjacentPairs()
+    XCTAssertEqual(pairs.startIndex, pairs.endIndex)
+    XCTAssert(Array(pairs) == [])
+  }
+
+  func testTwoElements() {
+    let pairs = (0..<2).adjacentPairs()
+    XCTAssert(Array(pairs) == [(0, 1)])
+  }
+
+  func testThreeElements() {
+    let pairs = (0..<3).adjacentPairs()
+    XCTAssert(Array(pairs) == [(0, 1), (1, 2)])
+  }
+
+  func testFourElements() {
+    let pairs = (0..<4).adjacentPairs()
+    XCTAssert(Array(pairs) == [(0, 1), (1, 2), (2, 3)])
+  }
+
+  func testForwardIndexing() {
+    let pairs = (1...5).adjacentPairs()
+    let expected = [(1, 2), (2, 3), (3, 4), (4, 5)]
+    var index = pairs.startIndex
+    for iteration in expected.indices {
+      XCTAssert(pairs[index] == expected[iteration])
+      pairs.formIndex(after: &index)
+    }
+    XCTAssertEqual(index, pairs.endIndex)
+  }
+
+  func testBackwardIndexing() {
+    let pairs = (1...5).adjacentPairs()
+    let expected = [(4, 5), (3, 4), (2, 3), (1, 2)]
+    var index = pairs.endIndex
+    for iteration in expected.indices {
+      pairs.formIndex(before: &index)
+      XCTAssert(pairs[index] == expected[iteration])
+    }
+    XCTAssertEqual(index, pairs.startIndex)
+  }
+
+  func testIndexDistance() {
+    let pairSequences = (0...4).map { (0..<$0).adjacentPairs() }
+
+    for pairs in pairSequences {
+      for index in pairs.indices.dropLast() {
+        let next = pairs.index(after: index)
+        XCTAssertEqual(pairs.distance(from: index, to: next), 1)
+      }
+
+      XCTAssertEqual(pairs.distance(from: pairs.startIndex, to: pairs.endIndex), pairs.count)
+      XCTAssertEqual(pairs.distance(from: pairs.endIndex, to: pairs.startIndex), -pairs.count)
+    }
+  }
+
+  func testIndexOffsetBy() {
+    let pairSequences = (0...4).map { (0..<$0).adjacentPairs() }
+
+    for pairs in pairSequences {
+      for index in pairs.indices.dropLast() {
+        let next = pairs.index(after: index)
+        XCTAssertEqual(pairs.index(index, offsetBy: 1), next)
+      }
+
+      XCTAssertEqual(pairs.index(pairs.startIndex, offsetBy: pairs.count), pairs.endIndex)
+      XCTAssertEqual(pairs.index(pairs.endIndex, offsetBy: -pairs.count), pairs.startIndex)
+    }
+  }
+}
+
+extension Collection {
+  fileprivate static func == <L: Equatable, R: Equatable> (lhs: Self, rhs: Self) -> Bool where Element == (L, R) {
+    lhs.count == rhs.count && zip(lhs, rhs).allSatisfy(==)
+  }
+}


### PR DESCRIPTION
Implements an `adjacentPairs` algorithm on Sequence, per forum discussion: https://forums.swift.org/t/add-an-adjacentpairs-algorithm-to-sequence/14817.

### Description
Lazily iterates over tuples of adjacent elements.

This operation is available for any sequence by calling the `adjacentPairs()` method.

```swift
let numbers = (1...5)
let pairs = numbers.adjacentPairs()
// Array(pairs) == [(1, 2), (2, 3), (3, 4), (4, 5)]
```

### Detailed Design
The `adjacentPairs()` method is declared as a `Sequence` extension returning `AdjacentPairs`.

```swift
extension Sequence {
  public func adjacentPairs() -> AdjacentPairs<Self>
}
```

The resulting `AdjacentPairs` type is a sequence, with conditional conformance to `Collection`, `BidirectionalCollection`, and `RandomAccessCollection` when the underlying sequence conforms.

The spelling `zip(s, s.dropFirst())` for a sequence `s` is an equivalent operation on collection types; however, this implementation is undefined behavior on single-pass sequences, and `Zip2Sequence` does not conditionally conform to the `Collection` family of protocols.

### Documentation Plan
- API introduced in AdjacentPairs.swift is documented.
- AdjacentPairs.md is included in Guides.
- README is updated.
- CHANGELOG is updated.

### Test Plan
Unit tests capture expected index-related invariants about `Collection` and verify expected behavior for sequences of varying lengths, including the empty and single-element sequence cases.

### Source Impact
This change is strictly additive.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
