### PR TITLE
[tests] Ensure correct implementation of hash computation for ChunkedByCount

### DIFF
--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -514,12 +514,13 @@ extension ChunkedByCount: Equatable where Base: Equatable {}
 // Since we have another stored property of type `Index` on the
 // collection, synthesis of `Hashble` conformace would require
 // a `Base.Index: Hashable` constraint, so we implement the hasher
-// only in terms of `base`. Since the computed index is based on it,
-// it should not make a difference here.
+// only in terms of `base` and `chunkCount`. Since the computed
+// index is based on it, it should not make a difference here.
 extension ChunkedByCount: Hashable where Base: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(base)
+    hasher.combine(chunkCount)
   }
 }
 extension ChunkedByCount.Index: Hashable where Base.Index: Hashable {}

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -145,4 +145,16 @@ final class ChunkedTests: XCTestCase {
       validateIndexTraversals(chunks)
     }
   }
+  
+  func testChunksOfCountHash() {
+    let collection1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    let collection2 = [1, 2, 3, 4, 5]
+    
+    XCTAssertEqualHashValue(
+      collection1.chunks(ofCount: 1), collection1.chunks(ofCount: 1))
+    XCTAssertNotEqualHashValue(
+      collection1.chunks(ofCount: 1), collection2.chunks(ofCount: 1))
+    XCTAssertNotEqualHashValue(
+      collection1.chunks(ofCount: 2), collection2.chunks(ofCount: 4))
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -203,6 +203,19 @@ func XCTAssertEqualHashValue<T: Hashable, U: Hashable>(
   )
 }
 
+/// Asserts that two hashable instances don't produce the same hash value.
+func XCTAssertNotEqualHashValue<T: Hashable, U: Hashable>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> U,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNotEqual(
+    hash(try expression1()), hash(try expression2()),
+    message(), file: file, line: line
+  )
+}
+
 /// Tests that all index traversal methods behave as expected.
 ///
 /// Verifies the correctness of the implementations of `startIndex`, `endIndex`,


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

After the Nate's comments about hashable correctness in the last PR I note that we have miss that on `ChunkedByCount`. 
This just adjust to take the count in hash computation. 

cc @natecook1000 @timvermeulen 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
