### PR TITLE
Add `joined(by:)`

### DIFF
--- a/Guides/Joined.md
+++ b/Guides/Joined.md
@@ -1,0 +1,102 @@
+#  Joined
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Joined.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/JoinedTests.swift)]
+
+Concatenate a sequence of sequences, inserting a separator between each element.
+
+The separator can be either a single element or a sequence of elements, and it
+can optionally depend on the sequences right before and after it by returning it
+from a closure:
+
+```swift
+for number in [[1], [2, 3], [4, 5, 6]].joined(by: 100) {
+    print(number)
+}
+// 1, 100, 2, 3, 100, 4, 5, 6
+
+for number in [[10], [20, 30], [40, 50, 60]].joined(by: { [$0.count, $1.count] }) {
+    print(number)
+}
+// 10, 1, 2, 20, 30, 2, 3, 40, 50, 60
+```
+
+## Detailed Design
+
+The versions that take a closure are executed eagerly and are defined on
+`Sequence`:
+
+```swift
+extension Sequence where Element: Sequence {
+    public func joined(
+        by separator: (Element, Element) throws -> Element.Element
+    ) rethrows -> [Element.Element]
+    
+    public func joined<Separator>(
+        by separator: (Element, Element) throws -> Separator
+    ) rethrows -> [Element.Element]
+        where Separator: Sequence, Separator.Element == Element.Element
+}
+```
+
+The versions that do not take a closure are defined on both `Sequence` and
+`Collection` because the resulting collections need to precompute their start
+index to ensure O(1) access:
+
+```swift
+extension Sequence where Element: Sequence {
+    public func joined(by separator: Element.Element)
+        -> JoinedBySequence<Self, CollectionOfOne<Element.Element>>
+        
+    public func joined<Separator>(
+        by separator: Separator
+    ) -> JoinedBySequence<Self, Separator>
+        where Separator: Collection, Separator.Element == Element.Element
+}
+
+extension Collection where Element: Sequence {
+    public func joined(by separator: Element.Element)
+        -> JoinedByCollection<Self, CollectionOfOne<Element.Element>>
+        
+    public func joined<Separator>(
+        by separator: Separator
+    ) -> JoinedByCollection<Self, Separator>
+        where Separator: Collection, Separator.Element == Element.Element
+}
+```
+
+Note that the sequence separator of the closure-less version defined on
+`Sequence` is required to be a `Collection`, because a plain `Sequence` cannot in
+general be iterated over multiple times.
+
+The closure-based versions also have lazy variants that are defined on both
+`LazySequenceProtocol` and `LazyCollectionProtocol` for the same reason as
+explained above:
+
+```swift
+extension LazySequenceProtocol where Element: Sequence {
+    public func joined(
+        by separator: @escaping (Element, Element) -> Element.Element
+    ) -> JoinedByClosureSequence<Self, CollectionOfOne<Element.Element>>
+  
+    public func joined<Separator>(
+        by separator: @escaping (Element, Element) -> Separator
+    ) -> JoinedByClosureSequence<Self, Separator>
+}
+
+extension LazyCollectionProtocol where Element: Collection {
+    public func joined(
+        by separator: @escaping (Element, Element) -> Element.Element
+    ) -> JoinedByClosureCollection<Self, CollectionOfOne<Element.Element>>
+  
+    public func joined<Separator>(
+        by separator: @escaping (Element, Element) -> Separator
+    ) -> JoinedByClosureCollection<Self, Separator>
+}
+```
+
+`JoinedBySequence`, `JoinedByClosureSequence`, `JoinedByCollection`, and
+`JoinedByClosureCollection` conform to `LazySequenceProtocol` when the base
+sequence conforms. `JoinedByCollection` and `JoinedByClosureCollection` also
+conform to `LazyCollectionProtocol` and `BidirectionalCollection` when the base
+collection conforms.

--- a/Sources/Algorithms/EitherSequence.swift
+++ b/Sources/Algorithms/EitherSequence.swift
@@ -62,17 +62,22 @@ internal enum EitherSequence<Left: Sequence, Right: Sequence>
 }
 
 extension EitherSequence: Sequence {
-  public struct Iterator: IteratorProtocol {
-    var left: Left.Iterator?
-    var right: Right.Iterator?
+  @usableFromInline
+  internal struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal var left: Left.Iterator?
     
-    public mutating func next() -> Left.Element? {
+    @usableFromInline
+    internal var right: Right.Iterator?
+    
+    @inlinable
+    internal mutating func next() -> Left.Element? {
       left?.next() ?? right?.next()
     }
   }
   
   @usableFromInline
-  func makeIterator() -> Iterator {
+  internal func makeIterator() -> Iterator {
     switch self {
     case .left(let left):
       return Iterator(left: left.makeIterator(), right: nil)

--- a/Sources/Algorithms/EitherSequence.swift
+++ b/Sources/Algorithms/EitherSequence.swift
@@ -13,6 +13,7 @@
 // Either
 //===----------------------------------------------------------------------===//
 
+/// A general-purpose sum type.
 @usableFromInline
 internal enum Either<Left, Right> {
   case left(Left)
@@ -53,6 +54,7 @@ extension Either: Comparable where Left: Comparable, Right: Comparable {
 // EitherSequence
 //===----------------------------------------------------------------------===//
 
+/// A sequence that has one of the two specified types.
 @usableFromInline
 internal enum EitherSequence<Left: Sequence, Right: Sequence>
   where Left.Element == Right.Element

--- a/Sources/Algorithms/EitherSequence.swift
+++ b/Sources/Algorithms/EitherSequence.swift
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Either
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+internal enum Either<Left, Right> {
+  case left(Left)
+  case right(Right)
+}
+
+extension Either: Equatable where Left: Equatable, Right: Equatable {
+  @usableFromInline
+  internal static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case let (.left(lhs), .left(rhs)):
+      return lhs == rhs
+    case let (.right(lhs), .right(rhs)):
+      return lhs == rhs
+    case (.left, .right), (.right, .left):
+      return false
+    }
+  }
+}
+
+extension Either: Comparable where Left: Comparable, Right: Comparable {
+  @usableFromInline
+  internal static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case let (.left(lhs), .left(rhs)):
+      return lhs < rhs
+    case let (.right(lhs), .right(rhs)):
+      return lhs < rhs
+    case (.left, .right):
+      return true
+    case (.right, .left):
+      return false
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// EitherSequence
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+internal enum EitherSequence<Left: Sequence, Right: Sequence>
+  where Left.Element == Right.Element
+{
+  case left(Left)
+  case right(Right)
+}
+
+extension EitherSequence: Sequence {
+  public struct Iterator: IteratorProtocol {
+    var left: Left.Iterator?
+    var right: Right.Iterator?
+    
+    public mutating func next() -> Left.Element? {
+      left?.next() ?? right?.next()
+    }
+  }
+  
+  @usableFromInline
+  func makeIterator() -> Iterator {
+    switch self {
+    case .left(let left):
+      return Iterator(left: left.makeIterator(), right: nil)
+    case .right(let right):
+      return Iterator(left: nil, right: right.makeIterator())
+    }
+  }
+}
+
+extension EitherSequence: Collection
+  where Left: Collection, Right: Collection, Left.Element == Right.Element
+{
+  @usableFromInline
+  internal typealias Index = Either<Left.Index, Right.Index>
+
+  @inlinable
+  internal var startIndex: Index {
+    switch self {
+    case .left(let s):
+      return .left(s.startIndex)
+    case .right(let s):
+      return .right(s.startIndex)
+    }
+  }
+
+  @inlinable
+  internal var endIndex: Index {
+    switch self {
+    case .left(let s):
+      return .left(s.endIndex)
+    case .right(let s):
+      return .right(s.endIndex)
+    }
+  }
+
+  @inlinable
+  internal subscript(position: Index) -> Element {
+    switch (self, position) {
+    case let (.left(s), .left(i)):
+      return s[i]
+    case let (.right(s), .right(i)):
+      return s[i]
+    default:
+      fatalError()
+    }
+  }
+
+  @inlinable
+  internal func index(after i: Index) -> Index {
+    switch (self,i) {
+    case let (.left(s), .left(i)):
+      return .left(s.index(after: i))
+    case let (.right(s), .right(i)):
+      return .right(s.index(after: i))
+    default:
+      fatalError()
+    }
+  }
+
+  @inlinable
+  internal func index(
+    _ i: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    switch (self, i, limit) {
+    case let (.left(s), .left(i), .left(limit)):
+      return s.index(i, offsetBy: distance, limitedBy: limit).map { .left($0) }
+    case let (.right(s), .right(i), .right(limit)):
+      return s.index(i, offsetBy: distance, limitedBy: limit).map { .right($0) }
+    default:
+      fatalError()
+    }
+  }
+
+  @inlinable
+  internal func index(_ i: Index, offsetBy distance: Int) -> Index {
+    switch (self, i) {
+    case let (.left(s), .left(i)):
+      return .left(s.index(i, offsetBy: distance))
+    case let (.right(s), .right(i)):
+      return .right(s.index(i, offsetBy: distance))
+    default:
+      fatalError()
+    }
+  }
+
+  @inlinable
+  internal func distance(from start: Index, to end: Index) -> Int {
+    switch (self, start, end) {
+    case let (.left(s), .left(i), .left(j)):
+      return s.distance(from: i, to: j)
+    case let (.right(s), .right(i), .right(j)):
+      return s.distance(from: i, to: j)
+    default:
+      fatalError()
+    }
+  }
+}
+
+extension EitherSequence: BidirectionalCollection
+  where Left: BidirectionalCollection, Right: BidirectionalCollection
+{
+  @inlinable
+  internal func index(before i: Index) -> Index {
+    switch (self, i) {
+    case let (.left(s), .left(i)):
+      return .left(s.index(before: i))
+    case let (.right(s), .right(i)):
+      return .right(s.index(before: i))
+    default:
+      fatalError()
+    }
+  }
+}
+
+extension EitherSequence: RandomAccessCollection
+  where Left: RandomAccessCollection, Right: RandomAccessCollection {}

--- a/Sources/Algorithms/FlattenCollection.swift
+++ b/Sources/Algorithms/FlattenCollection.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+internal struct FlattenCollection<Base: Collection> where Base.Element: Collection {
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let indexOfFirstNonEmptyElement: Base.Index
+  
+  @inlinable
+  internal init(base: Base) {
+    self.base = base
+    self.indexOfFirstNonEmptyElement = base.endOfPrefix(while: { $0.isEmpty })
+  }
+}
+
+extension FlattenCollection: Collection {
+  @usableFromInline
+  internal struct Index: Comparable {
+    @usableFromInline
+    internal let outer: Base.Index
+    
+    @usableFromInline
+    internal let inner: Base.Element.Index?
+    
+    @inlinable
+    init(outer: Base.Index, inner: Base.Element.Index?) {
+      self.outer = outer
+      self.inner = inner
+    }
+    
+    @inlinable
+    internal static func < (lhs: Self, rhs: Self) -> Bool {
+      guard lhs.outer == rhs.outer else { return lhs.outer < rhs.outer }
+      return lhs.inner == nil ? false : lhs.inner! < rhs.inner!
+    }
+  }
+  
+  @inlinable
+  internal var startIndex: Index {
+    let outer = indexOfFirstNonEmptyElement
+    let inner = outer == base.endIndex ? nil : base[outer].startIndex
+    return Index(outer: outer, inner: inner)
+  }
+  
+  @inlinable
+  internal var endIndex: Index {
+    Index(outer: base.endIndex, inner: nil)
+  }
+  
+  @inlinable
+  internal func index(after index: Index) -> Index {
+    let element = base[index.outer]
+    let nextInner = element.index(after: index.inner!)
+    
+    if nextInner == element.endIndex {
+      let nextOuter = base[base.index(after: index.outer)...]
+        .endOfPrefix(while: { $0.isEmpty })
+      let nextInner = nextOuter == base.endIndex
+        ? nil
+        : base[nextOuter].startIndex
+      return Index(outer: nextOuter, inner: nextInner)
+    } else {
+      return Index(outer: index.outer, inner: nextInner)
+    }
+  }
+  
+  @inlinable
+  internal subscript(position: Index) -> Base.Element.Element {
+    base[position.outer][position.inner!]
+  }
+  
+  @inlinable
+  internal func index(_ index: Index, offsetBy distance: Int) -> Index {
+    // TODO
+    fatalError()
+  }
+  
+  @inlinable
+  internal func index(
+    _ index: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    // TODO
+    fatalError()
+  }
+  
+  @inlinable
+  internal func distance(from start: Index, to end: Index) -> Int {
+    guard start.outer <= end.outer
+      else { return -distance(from: end, to: start) }
+    guard let startInner = start.inner
+      else { return 0 }
+    guard start.outer != end.outer
+      else { return base[start.outer].distance(from: startInner, to: end.inner!) }
+    
+    let firstPart = base[start.outer][startInner...].count
+    let middlePart = base[start.outer..<end.outer].dropFirst().reduce(0, { $0 + $1.count })
+    let lastPart = end.inner.map { base[end.outer][..<$0].count } ?? 0
+    
+    return firstPart + middlePart + lastPart
+  }
+}
+
+extension FlattenCollection: BidirectionalCollection
+  where Base: BidirectionalCollection, Base.Element: BidirectionalCollection
+{
+  @inlinable
+  internal func index(before index: Index) -> Index {
+    if let inner = index.inner {
+      let element = base[index.outer]
+      
+      if inner != element.startIndex {
+        let previousInner = element.index(before: inner)
+        return Index(outer: index.outer, inner: previousInner)
+      }
+    }
+    
+    let previousOuter = base[..<index.outer].lastIndex(where: { !$0.isEmpty })!
+    let element = base[previousOuter]
+    let previousInner = element.index(before: element.endIndex)
+    return Index(outer: previousOuter, inner: previousInner)
+  }
+}
+
+extension Collection where Element: Collection {
+  @inlinable
+  internal func joined() -> FlattenCollection<Self> {
+    FlattenCollection(base: self)
+  }
+}

--- a/Sources/Algorithms/FlattenCollection.swift
+++ b/Sources/Algorithms/FlattenCollection.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A collection consisting of all the elements contained in a collection of
+/// collections.
 @usableFromInline
 internal struct FlattenCollection<Base: Collection> where Base.Element: Collection {
   @usableFromInline
@@ -98,7 +100,8 @@ extension FlattenCollection: Collection {
       else { return base[start.outer].distance(from: startInner, to: end.inner!) }
     
     let firstPart = base[start.outer][startInner...].count
-    let middlePart = base[start.outer..<end.outer].dropFirst().reduce(0, { $0 + $1.count })
+    let middlePart = base[start.outer..<end.outer].dropFirst()
+      .reduce(0, { $0 + $1.count })
     let lastPart = end.inner.map { base[end.outer][..<$0].count } ?? 0
     
     return firstPart + middlePart + lastPart
@@ -226,7 +229,11 @@ extension FlattenCollection: Collection {
     if let indexInner = index.inner {
       let element = base[index.outer]
       
-      if let inner = element.index(indexInner, offsetBy: -remainder, limitedBy: element.startIndex) {
+      if let inner = element.index(
+          indexInner,
+          offsetBy: -remainder,
+          limitedBy: element.startIndex
+      ) {
         return Index(outer: index.outer, inner: inner)
       }
       
@@ -238,7 +245,11 @@ extension FlattenCollection: Collection {
     while outer != limit.outer {
       let element = base[outer]
       
-      if let inner = element.index(element.endIndex, offsetBy: -remainder, limitedBy: element.startIndex) {
+      if let inner = element.index(
+          element.endIndex,
+          offsetBy: -remainder,
+          limitedBy: element.startIndex
+      ) {
         return Index(outer: outer, inner: inner)
       }
       
@@ -247,8 +258,11 @@ extension FlattenCollection: Collection {
     }
     
     let element = base[outer]
-    return element.index(element.endIndex, offsetBy: -remainder, limitedBy: limit.inner!)
-      .map { inner in Index(outer: outer, inner: inner) }
+    return element.index(
+      element.endIndex,
+      offsetBy: -remainder,
+      limitedBy: limit.inner!
+    ).map { inner in Index(outer: outer, inner: inner) }
   }
 }
 
@@ -273,11 +287,18 @@ extension FlattenCollection: BidirectionalCollection
   }
 }
 
+extension FlattenCollection: LazySequenceProtocol
+  where Base: LazySequenceProtocol, Base.Element: LazySequenceProtocol {}
+extension FlattenCollection: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol, Base.Element: LazyCollectionProtocol {}
+
 //===----------------------------------------------------------------------===//
 // joined()
 //===----------------------------------------------------------------------===//
 
 extension Collection where Element: Collection {
+  /// Returns the concatenation of the elements in this collection of
+  /// collections.
   @inlinable
   internal func joined() -> FlattenCollection<Self> {
     FlattenCollection(base: self)

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -220,7 +220,8 @@ internal struct InterspersedMap<Base: Sequence, Result> {
 }
 
 extension InterspersedMap: Sequence {
-  public struct Iterator: IteratorProtocol {
+  @usableFromInline
+  internal struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var base: Base.Iterator
     
@@ -245,14 +246,14 @@ extension InterspersedMap: Sequence {
     }
     
     @usableFromInline
-    enum State {
+    internal enum State {
       case start
       case element(Base.Element)
       case separator(previous: Base.Element)
     }
 
     @inlinable
-    public mutating func next() -> Result? {
+    internal mutating func next() -> Result? {
       switch state {
       case .start:
         guard let first = base.next() else { return nil }
@@ -270,7 +271,7 @@ extension InterspersedMap: Sequence {
   }
 
   @inlinable
-  public func makeIterator() -> Iterator {
+  internal func makeIterator() -> Iterator {
     Iterator(
       base: base.makeIterator(),
       transform: transform,

--- a/Sources/Algorithms/Intersperse.swift
+++ b/Sources/Algorithms/Intersperse.swift
@@ -284,6 +284,10 @@ extension Intersperse: LazyCollectionProtocol
 // InterspersedMap
 //===----------------------------------------------------------------------===//
 
+
+/// A sequence over the results of applying a closure to the sequence's
+/// elements, with a separator that separates each pair of adjacent transformed
+/// values.
 @usableFromInline
 internal struct InterspersedMap<Base: Sequence, Result> {
   @usableFromInline
@@ -360,7 +364,7 @@ extension InterspersedMap: Collection where Base: Collection {
   @usableFromInline
   internal struct Index: Comparable {
     @usableFromInline
-    internal enum Representation {
+    internal enum Representation: Equatable {
       case element(Base.Index)
       case separator(previous: Base.Index, next: Base.Index)
     }
@@ -573,6 +577,14 @@ extension InterspersedMap: BidirectionalCollection
   }
 }
 
+extension InterspersedMap.Index.Representation: Hashable
+  where Base.Index: Hashable {}
+
+extension InterspersedMap: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+extension InterspersedMap: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
 //===----------------------------------------------------------------------===//
 // interspersed(with:)
 //===----------------------------------------------------------------------===//
@@ -616,8 +628,21 @@ extension Sequence {
 //===----------------------------------------------------------------------===//
 // lazy.interspersed(_:with:)
 //===----------------------------------------------------------------------===//
-  
+
 extension LazySequenceProtocol {
+  /// Returns a sequence over the results of applying a closure to the
+  /// sequence's elements, with a separator that separates each pair of adjacent
+  /// transformed values.
+  ///
+  /// The transformation closure lets you intersperse a sequence using a
+  /// separator of a different type than the original's sequence's elements.
+  /// Each separator is produced by a closure that is given access to the
+  /// two elements in the original sequence right before and after it.
+  ///
+  ///     let strings = [1, 2, 2].interspersedMap(String.init,
+  ///         with: { $0 == $1 ? " == " : " != " })
+  ///     print(strings.joined()) // "1 != 2 == 2"
+  ///
   @usableFromInline
   internal func interspersedMap<Result>(
     _ transform: @escaping (Element) -> Result,

--- a/Sources/Algorithms/Joined.swift
+++ b/Sources/Algorithms/Joined.swift
@@ -1,0 +1,423 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// JoinedBySequence
+//===----------------------------------------------------------------------===//
+
+public struct JoinedBySequence<Base: Sequence, Separator: Sequence>
+  where Base.Element: Sequence, Base.Element.Element == Separator.Element
+{
+  @usableFromInline
+  internal typealias Inner = FlattenSequence<
+    Intersperse<LazyMapSequence<Base, EitherSequence<Base.Element, Separator>>>>
+  
+  @usableFromInline
+  internal let inner: Inner
+  
+  @inlinable
+  internal init(base: Base, separator: Separator) {
+    self.inner = base.lazy
+      .map(EitherSequence.left)
+      .interspersed(with: .right(separator))
+      .joined()
+  }
+}
+
+extension JoinedBySequence: Sequence {
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal var inner: Inner.Iterator
+    
+    @inlinable
+    internal init(inner: Inner.Iterator) {
+      self.inner = inner
+    }
+    
+    @inlinable
+    public mutating func next() -> Base.Element.Element? {
+      inner.next()
+    }
+  }
+  
+  @inlinable
+  public func makeIterator() -> Iterator {
+    Iterator(inner: inner.makeIterator())
+  }
+}
+
+extension JoinedBySequence: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
+//===----------------------------------------------------------------------===//
+// JoinedByClosureSequence
+//===----------------------------------------------------------------------===//
+
+public struct JoinedByClosureSequence<Base: Sequence, Separator: Sequence>
+  where Base.Element: Sequence, Base.Element.Element == Separator.Element
+{
+  @usableFromInline
+  internal typealias Inner = FlattenSequence<
+    InterspersedMap<LazySequence<Base>, EitherSequence<Base.Element, Separator>>>
+  
+  @usableFromInline
+  internal let inner: Inner
+  
+  @inlinable
+  internal init(
+    base: Base,
+    separator: @escaping (Base.Element, Base.Element) -> Separator
+  ) {
+    self.inner = base.lazy
+      .interspersedMap(
+        EitherSequence.left,
+        by: { EitherSequence.right(separator($0, $1)) })
+      .joined()
+  }
+}
+
+extension JoinedByClosureSequence: Sequence {
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal var inner: Inner.Iterator
+    
+    @inlinable
+    internal init(inner: Inner.Iterator) {
+      self.inner = inner
+    }
+    
+    @inlinable
+    public mutating func next() -> Base.Element.Element? {
+      inner.next()
+    }
+  }
+  
+  @inlinable
+  public func makeIterator() -> Iterator {
+    Iterator(inner: inner.makeIterator())
+  }
+}
+
+extension JoinedByClosureSequence: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
+//===----------------------------------------------------------------------===//
+// JoinedByCollection
+//===----------------------------------------------------------------------===//
+
+public struct JoinedByCollection<Base: Collection, Separator: Collection>
+  where Base.Element: Collection, Base.Element.Element == Separator.Element
+{
+  @usableFromInline
+  internal typealias Inner = FlattenCollection<
+    Intersperse<LazyMapSequence<Base, EitherSequence<Base.Element, Separator>>>>
+  
+  @usableFromInline
+  internal let inner: Inner
+  
+  @inlinable
+  internal init(base: Base, separator: Separator) {
+    self.inner = base.lazy
+      .map(EitherSequence.left)
+      .interspersed(with: .right(separator))
+      .joined()
+  }
+}
+
+extension JoinedByCollection: Collection {
+  public struct Index: Comparable {
+    @usableFromInline
+    internal let inner: Inner.Index
+    
+    @inlinable
+    internal init(_ inner: Inner.Index) {
+      self.inner = inner
+    }
+    
+    @inlinable
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.inner == rhs.inner
+    }
+    
+    @inlinable
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.inner < rhs.inner
+    }
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    Index(inner.startIndex)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(inner.endIndex)
+  }
+  
+  @inlinable
+  public func index(after index: Index) -> Index {
+    Index(inner.index(after: index.inner))
+  }
+  
+  @inlinable
+  public subscript(position: Index) -> Base.Element.Element {
+    inner[position.inner]
+  }
+  
+  @inlinable
+  public func index(_ index: Index, offsetBy distance: Int) -> Index {
+    Index(inner.index(index.inner, offsetBy: distance))
+  }
+  
+  @inlinable
+  public func index(
+    _ index: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    inner.index(index.inner, offsetBy: distance, limitedBy: limit.inner)
+      .map(Index.init)
+  }
+  
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    inner.distance(from: start.inner, to: end.inner)
+  }
+}
+
+extension JoinedByCollection: BidirectionalCollection
+  where Base: BidirectionalCollection,
+        Base.Element: BidirectionalCollection,
+        Separator: BidirectionalCollection
+{
+  @inlinable
+  public func index(before index: Index) -> Index {
+    Index(inner.index(before: index.inner))
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// JoinedByClosureCollection
+//===----------------------------------------------------------------------===//
+
+public struct JoinedByClosureCollection<Base: Collection, Separator: Collection>
+  where Base.Element: Collection, Base.Element.Element == Separator.Element
+{
+  @usableFromInline
+  internal typealias Inner = FlattenCollection<
+    InterspersedMap<LazySequence<Base>, EitherSequence<Base.Element, Separator>>>
+  
+  @usableFromInline
+  internal let inner: Inner
+  
+  @inlinable
+  internal init(
+    base: Base,
+    separator: @escaping (Base.Element, Base.Element) -> Separator
+  ) {
+    self.inner = base.lazy
+      .interspersedMap(
+        EitherSequence.left,
+        by: { EitherSequence.right(separator($0, $1)) })
+      .joined()
+  }
+}
+
+extension JoinedByClosureCollection: Collection {
+  public struct Index: Comparable {
+    @usableFromInline
+    internal let inner: Inner.Index
+    
+    @inlinable
+    internal init(_ inner: Inner.Index) {
+      self.inner = inner
+    }
+    
+    @inlinable
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.inner == rhs.inner
+    }
+    
+    @inlinable
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.inner < rhs.inner
+    }
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    Index(inner.startIndex)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(inner.endIndex)
+  }
+  
+  @inlinable
+  public func index(after index: Index) -> Index {
+    Index(inner.index(after: index.inner))
+  }
+  
+  @inlinable
+  public subscript(position: Index) -> Base.Element.Element {
+    inner[position.inner]
+  }
+  
+  @inlinable
+  public func index(_ index: Index, offsetBy distance: Int) -> Index {
+    Index(inner.index(index.inner, offsetBy: distance))
+  }
+  
+  @inlinable
+  public func index(
+    _ index: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    inner.index(index.inner, offsetBy: distance, limitedBy: limit.inner)
+      .map(Index.init)
+  }
+  
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    inner.distance(from: start.inner, to: end.inner)
+  }
+}
+
+extension JoinedByClosureCollection: BidirectionalCollection
+  where Base: BidirectionalCollection,
+        Base.Element: BidirectionalCollection,
+        Separator: BidirectionalCollection
+{
+  @inlinable
+  public func index(before index: Index) -> Index {
+    Index(inner.index(before: index.inner))
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Sequence.joined(by:)
+//===----------------------------------------------------------------------===//
+
+extension Sequence where Element: Sequence {
+  @inlinable
+  public func joined(by separator: Element.Element)
+    -> JoinedBySequence<Self, CollectionOfOne<Element.Element>>
+  {
+    joined(by: CollectionOfOne(separator))
+  }
+  
+  @inlinable
+  public func joined<Separator>(
+    by separator: Separator
+  ) -> JoinedBySequence<Self, Separator>
+    where Separator: Collection, Separator.Element == Element.Element
+  {
+    JoinedBySequence(base: self, separator: separator)
+  }
+  
+  @inlinable
+  internal func _joined(
+    by update: (inout [Element.Element], Element, Element) throws -> Void
+  ) rethrows -> [Element.Element] {
+    var iterator = makeIterator()
+    guard let first = iterator.next() else { return [] }
+    
+    var result = Array(first)
+    var previous = first
+    
+    while let next = iterator.next() {
+      try update(&result, previous, next)
+      result.append(contentsOf: next)
+      previous = next
+    }
+    
+    return result
+  }
+  
+  @inlinable
+  public func joined(
+    by separator: (Element, Element) throws -> Element.Element
+  ) rethrows -> [Element.Element] {
+    try _joined(by: { $0.append(try separator($1, $2)) })
+  }
+  
+  @inlinable
+  public func joined<Separator>(
+    by separator: (Element, Element) throws -> Separator
+  ) rethrows -> [Element.Element]
+    where Separator: Sequence, Separator.Element == Element.Element
+  {
+    try _joined(by: { $0.append(contentsOf: try separator($1, $2)) })
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// LazySequenceProtocol.joined(by:)
+//===----------------------------------------------------------------------===//
+
+extension LazySequenceProtocol where Element: Sequence {
+  @inlinable
+  public func joined(
+    by separator: @escaping (Element, Element) -> Element.Element
+  ) -> JoinedByClosureSequence<Self, CollectionOfOne<Element.Element>> {
+    joined(by: { CollectionOfOne(separator($0, $1)) })
+  }
+  
+  @inlinable
+  public func joined<Separator>(
+    by separator: @escaping (Element, Element) -> Separator
+  ) -> JoinedByClosureSequence<Self, Separator> {
+    JoinedByClosureSequence(base: self, separator: separator)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Collection.joined(by:)
+//===----------------------------------------------------------------------===//
+
+extension Collection where Element: Collection {
+  @inlinable
+  public func joined(by separator: Element.Element)
+    -> JoinedByCollection<Self, CollectionOfOne<Element.Element>>
+  {
+    joined(by: CollectionOfOne(separator))
+  }
+  
+  @inlinable
+  public func joined<Separator>(by separator: Separator)
+    -> JoinedByCollection<Self, Separator>
+  {
+    JoinedByCollection(base: self, separator: separator)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// LazyCollectionProtocol.joined(by:)
+//===----------------------------------------------------------------------===//
+
+extension LazyCollectionProtocol where Element: Collection {
+  @inlinable
+  public func joined(
+    by separator: @escaping (Element, Element) -> Element.Element
+  ) -> JoinedByClosureCollection<Self, CollectionOfOne<Element.Element>> {
+    joined(by: { CollectionOfOne(separator($0, $1)) })
+  }
+  
+  @inlinable
+  public func joined<Separator>(
+    by separator: @escaping (Element, Element) -> Separator
+  ) -> JoinedByClosureCollection<Self, Separator> {
+    JoinedByClosureCollection(base: self, separator: separator)
+  }
+}

--- a/Sources/Algorithms/Joined.swift
+++ b/Sources/Algorithms/Joined.swift
@@ -13,6 +13,8 @@
 // JoinedBySequence
 //===----------------------------------------------------------------------===//
 
+/// A sequence that presents the elements of a base sequence of sequences
+/// concatenated using a given separator.
 public struct JoinedBySequence<Base: Sequence, Separator: Sequence>
   where Base.Element: Sequence, Base.Element.Element == Separator.Element
 {
@@ -61,6 +63,9 @@ extension JoinedBySequence: LazySequenceProtocol
 // JoinedByClosureSequence
 //===----------------------------------------------------------------------===//
 
+/// A sequence that presents the elements of a base sequence of sequences
+/// concatenated using a given separator that depends on the sequences right
+/// before and after it.
 public struct JoinedByClosureSequence<Base: Sequence, Separator: Sequence>
   where Base.Element: Sequence, Base.Element.Element == Separator.Element
 {
@@ -113,6 +118,8 @@ extension JoinedByClosureSequence: LazySequenceProtocol
 // JoinedByCollection
 //===----------------------------------------------------------------------===//
 
+/// A collection that presents the elements of a base collection of collections
+/// concatenated using a given separator.
 public struct JoinedByCollection<Base: Collection, Separator: Collection>
   where Base.Element: Collection, Base.Element.Element == Separator.Element
 {
@@ -205,10 +212,18 @@ extension JoinedByCollection: BidirectionalCollection
   }
 }
 
+extension JoinedByCollection: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+extension JoinedByCollection: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
 //===----------------------------------------------------------------------===//
 // JoinedByClosureCollection
 //===----------------------------------------------------------------------===//
 
+/// A collection that presents the elements of a base collection of collections
+/// concatenated using a given separator that depends on the collections right
+/// before and after it.
 public struct JoinedByClosureCollection<Base: Collection, Separator: Collection>
   where Base.Element: Collection, Base.Element.Element == Separator.Element
 {
@@ -305,11 +320,23 @@ extension JoinedByClosureCollection: BidirectionalCollection
   }
 }
 
+extension JoinedByClosureCollection: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+extension JoinedByClosureCollection: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
 //===----------------------------------------------------------------------===//
 // Sequence.joined(by:)
 //===----------------------------------------------------------------------===//
 
 extension Sequence where Element: Sequence {
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the given separator between each sequence.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: 100) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 100, 3, 4, 100, 5, 6
   @inlinable
   public func joined(by separator: Element.Element)
     -> JoinedBySequence<Self, CollectionOfOne<Element.Element>>
@@ -317,6 +344,13 @@ extension Sequence where Element: Sequence {
     joined(by: CollectionOfOne(separator))
   }
   
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the given separator between each sequence.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: [100, 200]) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 100, 200, 3, 4, 100, 200, 5, 6
   @inlinable
   public func joined<Separator>(
     by separator: Separator
@@ -345,6 +379,13 @@ extension Sequence where Element: Sequence {
     return result
   }
   
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the separator produced by the closure between each sequence.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: { $0.last! * $1.first! }) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 6, 3, 4, 20, 5, 6
   @inlinable
   public func joined(
     by separator: (Element, Element) throws -> Element.Element
@@ -352,6 +393,13 @@ extension Sequence where Element: Sequence {
     try _joined(by: { $0.append(try separator($1, $2)) })
   }
   
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the separator produced by the closure between each sequence.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: { [100 * $0.last!, 100 * $1.first!] }) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 200, 300, 3, 4, 400, 500, 5, 6
   @inlinable
   public func joined<Separator>(
     by separator: (Element, Element) throws -> Separator
@@ -367,6 +415,8 @@ extension Sequence where Element: Sequence {
 //===----------------------------------------------------------------------===//
 
 extension LazySequenceProtocol where Element: Sequence {
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the separator produced by the closure between each sequence.
   @inlinable
   public func joined(
     by separator: @escaping (Element, Element) -> Element.Element
@@ -374,6 +424,8 @@ extension LazySequenceProtocol where Element: Sequence {
     joined(by: { CollectionOfOne(separator($0, $1)) })
   }
   
+  /// Returns the concatenation of the elements in this sequence of sequences,
+  /// inserting the separator produced by the closure between each sequence.
   @inlinable
   public func joined<Separator>(
     by separator: @escaping (Element, Element) -> Separator
@@ -387,6 +439,13 @@ extension LazySequenceProtocol where Element: Sequence {
 //===----------------------------------------------------------------------===//
 
 extension Collection where Element: Collection {
+  /// Returns the concatenation of the elements in this collection of
+  /// collections, inserting the given separator between each collection.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: 100) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 100, 3, 4, 100, 5, 6
   @inlinable
   public func joined(by separator: Element.Element)
     -> JoinedByCollection<Self, CollectionOfOne<Element.Element>>
@@ -394,6 +453,13 @@ extension Collection where Element: Collection {
     joined(by: CollectionOfOne(separator))
   }
   
+  /// Returns the concatenation of the elements in this collection of
+  /// collections, inserting the given separator between each collection.
+  ///
+  ///     for x in [[1, 2], [3, 4], [5, 6]].joined(by: [100, 200]) {
+  ///         print(x)
+  ///     }
+  ///     // 1, 2, 100, 200, 3, 4, 100, 200, 5, 6
   @inlinable
   public func joined<Separator>(by separator: Separator)
     -> JoinedByCollection<Self, Separator>
@@ -407,6 +473,9 @@ extension Collection where Element: Collection {
 //===----------------------------------------------------------------------===//
 
 extension LazyCollectionProtocol where Element: Collection {
+  /// Returns the concatenation of the elements in this collection of
+  /// collections, inserting the separator produced by the closure between each
+  /// sequence.
   @inlinable
   public func joined(
     by separator: @escaping (Element, Element) -> Element.Element
@@ -414,6 +483,9 @@ extension LazyCollectionProtocol where Element: Collection {
     joined(by: { CollectionOfOne(separator($0, $1)) })
   }
   
+  /// Returns the concatenation of the elements in this collection of
+  /// collections, inserting the separator produced by the closure between each
+  /// sequence.
   @inlinable
   public func joined<Separator>(
     by separator: @escaping (Element, Element) -> Separator

--- a/Sources/Algorithms/Joined.swift
+++ b/Sources/Algorithms/Joined.swift
@@ -79,7 +79,7 @@ public struct JoinedByClosureSequence<Base: Sequence, Separator: Sequence>
     self.inner = base.lazy
       .interspersedMap(
         EitherSequence.left,
-        by: { EitherSequence.right(separator($0, $1)) })
+        with: { EitherSequence.right(separator($0, $1)) })
       .joined()
   }
 }
@@ -227,7 +227,7 @@ public struct JoinedByClosureCollection<Base: Collection, Separator: Collection>
     self.inner = base.lazy
       .interspersedMap(
         EitherSequence.left,
-        by: { EitherSequence.right(separator($0, $1)) })
+        with: { EitherSequence.right(separator($0, $1)) })
       .joined()
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -64,14 +64,29 @@ final class IntersperseTests: XCTestCase {
   }
   
   func testInterspersedMap() {
+    XCTAssertEqualSequences(
+      (0..<0).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
+      [])
+    
+    XCTAssertEqualSequences(
+      (0..<1).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
+      [0])
+    
+    XCTAssertEqualSequences(
+      (0..<5).lazy.interspersedMap({ $0 }, with: { $0 + $1 + 100 }),
+      [0, 101, 1, 103, 2, 105, 3, 107, 4])
+  }
+  
+  func testInterspersedMapLazy() {
+    XCTAssertLazySequence(AnySequence([]).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }))
+    XCTAssertLazyCollection((0..<0).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }))
+  }
+    
+  func testInterspersedMapIndexTraversals() {
     validateIndexTraversals(
       (0..<0).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
       (0..<1).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
       (0..<2).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
       (0..<5).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }))
-    
-    print(Array((1...5).lazy.interspersedMap(String.init, with: { left, right in
-      fatalError()
-    }).striding(by: 2)))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IntersperseTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 final class IntersperseTests: XCTestCase {
   func testSequence() {
@@ -61,5 +61,17 @@ final class IntersperseTests: XCTestCase {
   func testIntersperseLazy() {
     XCTAssertLazySequence((1...).prefix(0).lazy.interspersed(with: 0))
     XCTAssertLazyCollection("ABCDE".lazy.interspersed(with: "-"))
+  }
+  
+  func testInterspersedMap() {
+    validateIndexTraversals(
+      (0..<0).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
+      (0..<1).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
+      (0..<2).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }),
+      (0..<5).lazy.interspersedMap({ $0 }, with: { _, _ in 100 }))
+    
+    print(Array((1...5).lazy.interspersedMap(String.init, with: { left, right in
+      fatalError()
+    }).striding(by: 2)))
   }
 }

--- a/Tests/SwiftAlgorithmsTests/JoinedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/JoinedTests.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class JoinedTests: XCTestCase {
+  func testSequence() {
+    for x in [0..<0, 0..<0, 0..<5, 5..<10, 10..<15, 15..<15].joined(by: [100, 101]) {
+      print(x)
+    }
+  }
+  
+  func testIndexTraversals() {
+    validateIndexTraversals(
+      [0..<3, 3..<6].joined(by: 100),
+      [0..<0, 0..<5, 3..<6].joined(by: 100),
+      [0..<3, 3..<6, 6..<6].joined(by: 100),
+      [0..<0, 0..<0, 0..<3, 3..<6, 6..<6, 6..<6].joined(by: 100))
+    
+    let elements: [[Range<Int>]] = [
+      [],
+      [0..<0],
+      [0..<3],
+      [0..<3, 3..<6],
+      [0..<0, 0..<5, 3..<6, 6..<6],
+      [0..<0, 0..<0, 0..<3, 3..<6, 6..<6, 6..<6]
+    ]
+    
+    let separators: [[Int]] = [[], [100], [100, 101]]
+    
+    for (collection, separator) in product(elements, separators) {
+      validateIndexTraversals(collection.joined(by: separator))
+    }
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/JoinedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/JoinedTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import Algorithms
+@testable import Algorithms
 
 final class JoinedTests: XCTestCase {
   func testSequence() {
@@ -19,21 +19,29 @@ final class JoinedTests: XCTestCase {
     }
   }
   
-  func testIndexTraversals() {
+  func testJoinedIndexTraversals() {
     validateIndexTraversals(
-      [0..<3, 3..<6].joined(by: 100),
-      [0..<0, 0..<5, 3..<6].joined(by: 100),
-      [0..<3, 3..<6, 6..<6].joined(by: 100),
-      [0..<0, 0..<0, 0..<3, 3..<6, 6..<6, 6..<6].joined(by: 100))
-    
+      [].joined(),
+      [[]].joined(),
+      [[], []].joined(),
+      [[0]].joined(),
+      [[], [0], [1, 2], [3], []].joined(),
+      [[], [], [0], [1], [], [], [2, 3], [], []].joined())
+  }
+  
+  func testJoinedByIndexTraversals() {
     let elements: [[Range<Int>]] = [
       [],
       [0..<0],
       [0..<3],
       [0..<3, 3..<6],
-      [0..<0, 0..<5, 3..<6, 6..<6],
-      [0..<0, 0..<0, 0..<3, 3..<6, 6..<6, 6..<6]
+      [0..<0, 0..<3, 3..<6, 6..<6],
+      [0..<0, 0..<0, 0..<3, 3..<3, 3..<6, 6..<6, 6..<6]
     ]
+    
+    for collection in elements {
+      validateIndexTraversals(collection.joined(by: 100))
+    }
     
     let separators: [[Int]] = [[], [100], [100, 101]]
     


### PR DESCRIPTION
This PR adds 4 ways of joining sequences of sequences with a separator, two of which let you base the separator on the sequences right before and after it:

```swift
extension Sequence where Element: Sequence {
  public func joined(by separator: Element.Element)
    -> JoinedBySequence<Self, CollectionOfOne<Element.Element>>
  
  public func joined<Separator>(
    by separator: Separator
  ) -> JoinedBySequence<Self, Separator>
    where Separator: Collection, Separator.Element == Element.Element
  
  public func joined(
    by separator: (Element, Element) throws -> Element.Element
  ) rethrows -> [Element.Element]
  
  public func joined<Separator>(
    by separator: (Element, Element) throws -> Separator
  ) rethrows -> [Element.Element]
    where Separator: Sequence, Separator.Element == Element.Element
}
```

Also adds the following building blocks internally:

* `Either` and `EitherSequence`
* `FlattenCollection` that flattens a collection of collections without separators
* `InterspersedMap` that maps the sequence's elements and intersperses them with new elements at the same time

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
