### PR TITLE
Adjacent pairs wrapping

### DIFF
--- a/Sources/Algorithms/AdjacentPairs.swift
+++ b/Sources/Algorithms/AdjacentPairs.swift
@@ -144,7 +144,7 @@ public struct AdjacentPairsCollection<Base: Collection> {
       return
     }
     
-    // If there's only one element (i.e. the second index of base == endIndex)
+    // If there's only one element (i.e., the second index of base == endIndex),
     // then this collection should be empty.
     let secondIndex = base.index(after: base.startIndex)
     self.startIndex = secondIndex == base.endIndex

--- a/Sources/Algorithms/AdjacentPairs.swift
+++ b/Sources/Algorithms/AdjacentPairs.swift
@@ -60,7 +60,7 @@ extension Collection {
 public struct AdjacentPairsSequence<Base: Sequence> {
   @usableFromInline
   internal let base: Base
-
+  
   /// Creates an instance that makes pairs of adjacent elements from `base`.
   @inlinable
   internal init(base: Base) {
@@ -86,7 +86,7 @@ extension AdjacentPairsSequence {
 
 extension AdjacentPairsSequence.Iterator: IteratorProtocol {
   public typealias Element = (Base.Element, Base.Element)
-
+  
   @inlinable
   public mutating func next() -> Element? {
     if previousElement == nil {
@@ -107,7 +107,7 @@ extension AdjacentPairsSequence: Sequence {
   public func makeIterator() -> Iterator {
     Iterator(base: base.makeIterator())
   }
-
+  
   @inlinable
   public var underestimatedCount: Int {
     Swift.max(0, base.underestimatedCount - 1)
@@ -125,9 +125,9 @@ extension AdjacentPairsSequence: LazySequenceProtocol
 public struct AdjacentPairsCollection<Base: Collection> {
   @usableFromInline
   internal let base: Base
-
+  
   public let startIndex: Index
-
+  
   @inlinable
   internal init(base: Base) {
     self.base = base
@@ -137,7 +137,7 @@ public struct AdjacentPairsCollection<Base: Collection> {
     var endIndex: Index {
       Index(first: base.endIndex, second: base.endIndex)
     }
-
+    
     // Precompute `startIndex` to ensure O(1) behavior.
     guard !base.isEmpty else {
       self.startIndex = endIndex
@@ -155,7 +155,7 @@ public struct AdjacentPairsCollection<Base: Collection> {
 
 extension AdjacentPairsCollection {
   public typealias Iterator = AdjacentPairsSequence<Base>.Iterator
-
+  
   @inlinable
   public func makeIterator() -> Iterator {
     Iterator(base: base.makeIterator())
@@ -170,13 +170,13 @@ extension AdjacentPairsCollection {
     
     @usableFromInline
     internal var second: Base.Index
-
+    
     @inlinable
     internal init(first: Base.Index, second: Base.Index) {
       self.first = first
       self.second = second
     }
-
+    
     @inlinable
     public static func ==(lhs: Index, rhs: Index) -> Bool {
       lhs.first == rhs.first
@@ -194,12 +194,12 @@ extension AdjacentPairsCollection: Collection {
   public var endIndex: Index {
     Index(first: base.endIndex, second: base.endIndex)
   }
-
+  
   @inlinable
   public subscript(position: Index) -> (Base.Element, Base.Element) {
     (base[position.first], base[position.second])
   }
-
+  
   @inlinable
   public func index(after i: Index) -> Index {
     precondition(i != endIndex, "Can't advance beyond endIndex")
@@ -208,18 +208,18 @@ extension AdjacentPairsCollection: Collection {
       ? endIndex
       : Index(first: i.second, second: next)
   }
-
+  
   @inlinable
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     guard distance != 0 else { return i }
-
+    
     guard let result = distance > 0
       ? offsetForward(i, by: distance, limitedBy: endIndex)
       : offsetBackward(i, by: -distance, limitedBy: startIndex)
     else { fatalError("Index out of bounds") }
     return result
   }
-
+  
   @inlinable
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
@@ -260,7 +260,7 @@ extension AdjacentPairsCollection: Collection {
   ) -> Index? {
     assert(distance > 0)
     assert(limit < i)
-        
+    
     let offset = i == endIndex ? 0 : 1
     guard let newSecond = base.index(
       i.first,
@@ -271,7 +271,7 @@ extension AdjacentPairsCollection: Collection {
     precondition(newFirst >= base.startIndex, "Can't move before startIndex")
     return Index(first: newFirst, second: newSecond)
   }
-
+  
   @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     // While there's a 2-step gap between the `first` base index values in
@@ -280,7 +280,7 @@ extension AdjacentPairsCollection: Collection {
     // entire collection.
     base.distance(from: start.second, to: end.second)
   }
-
+  
   @inlinable
   public var count: Int {
     Swift.max(0, base.count - 1)

--- a/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
@@ -18,9 +18,19 @@ final class AdjacentPairsTests: XCTestCase {
     XCTAssertEqualSequences(pairs, [], by: ==)
   }
   
+  func testEmptySequenceWrapped() {
+    let pairs = (0...).prefix(0).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
   func testOneElementSequence() {
     let pairs = (0...).prefix(1).adjacentPairs()
     XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
+  func testOneElementSequenceWrapping() {
+    let pairs = (0...).prefix(1).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 0)], by: ==)
   }
   
   func testTwoElementSequence() {
@@ -28,15 +38,32 @@ final class AdjacentPairsTests: XCTestCase {
     XCTAssertEqualSequences(pairs, [(0, 1)], by: ==)
   }
   
+  func testTwoElementSequenceWrapping() {
+    let pairs = (0...).prefix(2).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 0)], by: ==)
+  }
+  
   func testThreeElementSequence() {
     let pairs = (0...).prefix(3).adjacentPairs()
     XCTAssertEqualSequences(pairs, [(0, 1), (1, 2)], by: ==)
+  }
+  
+  func testThreeElementSequenceWrapping() {
+    let pairs = (0...).prefix(3).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 2), (2, 0)], by: ==)
   }
   
   func testManySequences() {
     for n in 4...100 {
       let pairs = (0...).prefix(n).adjacentPairs()
       XCTAssertEqualSequences(pairs, zip(0..., 1...).prefix(n - 1), by: ==)
+    }
+  }
+  
+  func testManySequencesWrapping() {
+    for n in 4...100 {
+      let pairs = (0...).prefix(n).adjacentPairs(wrapping: true)
+      XCTAssertEqualSequences(pairs, chain(zip(0..., 1...).prefix(n - 1), [((n - 1), 0)]), by: ==)
     }
   }
   

--- a/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
@@ -45,30 +45,30 @@ final class AdjacentPairsTests: XCTestCase {
     XCTAssertEqual(pairs.startIndex, pairs.endIndex)
     XCTAssertEqualSequences(pairs, [], by: ==)
   }
-
+  
   func testOneElement() {
     let pairs = (0..<1).adjacentPairs()
     XCTAssertEqual(pairs.startIndex, pairs.endIndex)
     XCTAssertEqualSequences(pairs, [], by: ==)
   }
-
+  
   func testTwoElements() {
     let pairs = (0..<2).adjacentPairs()
     XCTAssertEqualSequences(pairs, [(0, 1)], by: ==)
   }
-
+  
   func testThreeElements() {
     let pairs = (0..<3).adjacentPairs()
     XCTAssertEqualSequences(pairs, [(0, 1), (1, 2)], by: ==)
   }
-
+  
   func testManyElements() {
     for n in 4...100 {
       let pairs = (0..<n).adjacentPairs()
       XCTAssertEqualSequences(pairs, zip(0..., 1...).prefix(n - 1), by: ==)
     }
   }
-
+  
   func testIndexTraversals() {
     validateIndexTraversals(
       (0..<0).adjacentPairs(),

--- a/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
+++ b/Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift
@@ -73,10 +73,21 @@ final class AdjacentPairsTests: XCTestCase {
     XCTAssertEqualSequences(pairs, [], by: ==)
   }
   
+  func testZeroElementsWrapping() {
+    let pairs = (0..<0).adjacentPairs(wrapping: true)
+    XCTAssertEqual(pairs.startIndex, pairs.endIndex)
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
   func testOneElement() {
     let pairs = (0..<1).adjacentPairs()
     XCTAssertEqual(pairs.startIndex, pairs.endIndex)
     XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
+  func testOneElementWrapping() {
+    let pairs = (0..<1).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 0)], by: ==)
   }
   
   func testTwoElements() {
@@ -84,15 +95,32 @@ final class AdjacentPairsTests: XCTestCase {
     XCTAssertEqualSequences(pairs, [(0, 1)], by: ==)
   }
   
+  func testTwoElementsWrapping() {
+    let pairs = (0..<2).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 0)], by: ==)
+  }
+  
   func testThreeElements() {
     let pairs = (0..<3).adjacentPairs()
     XCTAssertEqualSequences(pairs, [(0, 1), (1, 2)], by: ==)
+  }
+  
+  func testThreeElementsWrapping() {
+    let pairs = (0..<3).adjacentPairs(wrapping: true)
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 2), (2, 0)], by: ==)
   }
   
   func testManyElements() {
     for n in 4...100 {
       let pairs = (0..<n).adjacentPairs()
       XCTAssertEqualSequences(pairs, zip(0..., 1...).prefix(n - 1), by: ==)
+    }
+  }
+  
+  func testManyElementsWrapping() {
+    for n in 4...100 {
+      let pairs = (0..<n).adjacentPairs(wrapping: true)
+      XCTAssertEqualSequences(pairs, chain(zip(0..., 1...).prefix(n - 1), [((n - 1), 0)]), by: ==)
     }
   }
   
@@ -104,8 +132,21 @@ final class AdjacentPairsTests: XCTestCase {
       (0..<5).adjacentPairs())
   }
   
+  func testIndexTraversalsWrapping() {
+    validateIndexTraversals(
+      (0..<0).adjacentPairs(wrapping: true),
+      (0..<1).adjacentPairs(wrapping: true),
+      (0..<2).adjacentPairs(wrapping: true),
+      (0..<5).adjacentPairs(wrapping: true))
+  }
+  
   func testLaziness() {
     XCTAssertLazySequence((0...).lazy.adjacentPairs())
     XCTAssertLazyCollection((0..<100).lazy.adjacentPairs())
+  }
+  
+  func testLazinessWrapping() {
+    XCTAssertLazySequence((0...).lazy.adjacentPairs(wrapping: true))
+    XCTAssertLazyCollection((0..<100).lazy.adjacentPairs(wrapping: true))
   }
 }


### PR DESCRIPTION
### Description
Adds an optional `wrapping` parameter to `adjacentPairs` algorithm that allows you to include a pair of the last and first element.

### Detailed Design
```swift
extension Sequence {
  /// …
  ///
  /// The following example uses `adjacentPairs(wrapping: true)` to iterate over
  /// adjacent pairs of integers, including the last and first:
  ///
  ///     for pair in (1...).prefix(5).adjacentPairs(wrapping: true) {
  ///         print(pair)
  ///     }
  ///     // Prints "(1, 2)"
  ///     // Prints "(2, 3)"
  ///     // Prints "(3, 4)"
  ///     // Prints "(4, 5)"
  ///     // Prints "(5, 1)"
  ///
  /// - Parameter wrapping: If `true`, include the pair of the last and first
  /// elements of the sequence as the last elements of the returned collection.
  /// Defaults to `false`.
  @inlinable
  public func adjacentPairs(wrapping: Bool = false) -> AdjacentPairsSequence<Self> {
    AdjacentPairsSequence(base: self, wrapping: wrapping)
  }
}

extension Collection {
  /// …
  ///
  /// - Parameter wrapping: If `true`, include the pair of the last and first
  /// elements of the collection as the last elements of the returned
  /// collection. Defaults to `false`.
  @inlinable
  public func adjacentPairs(wrapping: Bool = false) -> AdjacentPairsCollection<Self> {
    AdjacentPairsCollection(base: self, wrapping: wrapping)
  }
}
```

### Alternatives Considered
- A new `Sequence` and `Collection` algorithm. This would have resulted in a lot of duplicate code from `AdjacentPairs` that would be better shared between the implementations.

### Documentation Plan
I’ll waiting to hear feedback on whether or not this is desirable and on the direction before diving into the documentation too much.
- [ ] Improve inline documentation
- [ ] Update `Guides/AdjacentPairs.md`
- [ ] `README.md`

### Test Plan
For each of the existing `adjacentPairs` unit tests, I’ve added one that tests the wrapping behavior as well.

### Source Impact
Existing calls to `adjacentPairs()` continues to work as-is since the `wrapping` parameter has a default value of `false`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
