### PR TITLE
Make chunked(on:) include subject value in Element type

### DIFF
--- a/Guides/Chunked.md
+++ b/Guides/Chunked.md
@@ -22,18 +22,20 @@ let chunks = numbers.chunked(by: { $0 <= $1 })
 
 The `chunk(on:)` method, by contrast, takes a projection of each element and
 separates chunks where the projection of two consecutive elements is not equal.
+The result includes both the projected value and the subsequence 
+that groups elements with that projected value:
 
 ```swift
 let names = ["David", "Kyle", "Karoy", "Nate"]
 let chunks = names.chunked(on: \.first!)
-// [["David"], ["Kyle", "Karoy"], ["Nate"]] 
+// [("D", ["David"]), ("K", ["Kyle", "Karoy"]), ("N", ["Nate"])] 
 ```
 
-The `chunks(ofCount:)` takes a `count` parameter (required to be > 0) and separates 
-the collection into `n` chunks of this given count. If the `count` parameter is 
-evenly divided by the count of the base `Collection` all the chunks will have 
-the count equals to the parameter. Otherwise, the last chunk will contain the 
-remaining elements.
+The `chunks(ofCount:)` method takes a `count` parameter (greater than zero) 
+and separates the collection into chunks of this given count.
+If the `count` parameter is evenly divided by the count of the base `Collection`,
+all the chunks will have a count equal to the parameter. 
+Otherwise, the last chunk will contain the remaining elements.
  
 ```swift
 let names = ["David", "Kyle", "Karoy", "Nate"]
@@ -44,16 +46,16 @@ let remaining = names.chunks(ofCount: 3)
 // equivalent to [["David", "Kyle", "Karoy"], ["Nate"]]
 ```
 
-The `chunks(ofCount:)` is the method of the [existing SE proposal][proposal]. 
-Unlike the `split` family of methods, the entire collection is included in the
-chunked result — joining the resulting chunks recreates the original collection. 
+The  `chunks(ofCount:)` is the subject of an [existing SE proposal][proposal].
+
+When "chunking" a collection, the entire collection is included in the result, 
+unlike the `split` family of methods, where separators are dropped.
+Joining the result of a chunking method call recreates the original collection. 
 
 ```swift
 c.elementsEqual(c.chunked(...).joined())
 // true
 ```
-
-Check the [proposal][proposal] detailed design section for more info. 
 
 [proposal]: https://github.com/apple/swift-evolution/pull/935
 
@@ -70,21 +72,21 @@ extension Collection {
 
     public func chunked<Subject: Equatable>(
         on projection: (Element) -> Subject
-    ) -> [SubSequence]
+    ) -> [(Subject, SubSequence)]
   }
 
   extension LazyCollectionProtocol {
     public func chunked(
         by belongInSameGroup: @escaping (Element, Element) -> Bool
-    ) -> Chunked<Elements>
+    ) -> ChunkedBy<Elements, Element>
 
     public func chunked<Subject: Equatable>(
         on projection: @escaping (Element) -> Subject
-    ) -> Chunked<Elements>
+    ) -> ChunkedOn<Elements, Subject>
 }
 ```
 
-The `Chunked` type is bidirectional when the wrapped collection is
+The `ChunkedBy` and `ChunkedOn` types are bidirectional when the wrapped collection is
 bidirectional.
 
 ### Complexity

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -47,8 +47,12 @@ final class ChunkedTests: XCTestCase {
   func testSimple() {
     // Example
     let names = ["David", "Kyle", "Karoy", "Nate"]
-    let chunks = names.chunked(on: { $0.first })
-    XCTAssertEqualSequences([["David"], ["Kyle", "Karoy"], ["Nate"]], chunks)
+    let chunks = names.chunked(on: { $0.first! })
+    let expected: [(Character, ArraySlice<String>)] = [
+      ("D", ["David"]),
+      ("K", ["Kyle", "Karoy"]),
+      ("N", ["Nate"])]
+    XCTAssertEqualSequences(expected, chunks, by: ==)
     
     // Empty sequence
     XCTAssertEqual(0, names.prefix(0).chunked(on: { $0.first }).count)
@@ -59,10 +63,11 @@ final class ChunkedTests: XCTestCase {
   }
   
   func testChunkedOn() {
-    validateFruitChunks(fruits.chunked(on: { $0.first }))
+    validateFruitChunks(fruits.chunked(on: { $0.first }).map { $1 })
     
     let lazyChunks = fruits.lazy.chunked(on: { $0.first })
-    validateFruitChunks(lazyChunks)
+    validateFruitChunks(lazyChunks.map { $1 })
+    validateIndexTraversals(lazyChunks)
   }
 
   func testChunkedBy() {
@@ -70,6 +75,7 @@ final class ChunkedTests: XCTestCase {
     
     let lazyChunks = fruits.lazy.chunked(by: { $0.first == $1.first })
     validateFruitChunks(lazyChunks)
+    validateIndexTraversals(lazyChunks)
   }
   
   func testChunkedLazy() {
@@ -77,10 +83,10 @@ final class ChunkedTests: XCTestCase {
     XCTAssertLazySequence(fruits.lazy.chunked(on: { $0.first }))
   }
   
-  
   //===----------------------------------------------------------------------===//
   // Tests for `chunks(ofCount:)`
   //===----------------------------------------------------------------------===//
+  
   func testChunksOfCount() {
     XCTAssertEqualSequences([Int]().chunks(ofCount: 1), [])
     XCTAssertEqualSequences([Int]().chunks(ofCount: 5), [])


### PR DESCRIPTION
This PR changes the result of calling `chunked(on:)` to `[(Subject, SubSequence)]`, and adds a new collection type as the result of `lazy.chunked(on:)` with a matching element type. Including the projected `Subject` is often useful when chunking on a projected value like this.

The new versions of `chunked(on:)` looks like this:

```swift
extension Collection {
  public func chunked<Subject: Equatable>(
    on projection: (Element) throws -> Subject
  ) rethrows -> [(Subject, SubSequence)]
}

extension LazyCollectionProtocol {
  public func chunked<Subject: Equatable>(
    on projection: (Element) throws -> Subject
  ) rethrows -> ChunkedOn<Self, Subject>
}
```

I've also changed the name `Chunked` to be `ChunkedBy`, since this PR introduces `ChunkedOn`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
