### PR TITLE
Remove compilation bottleneck for Swift 5.3.2 builds

### DIFF
--- a/Sources/Algorithms/Stride.swift
+++ b/Sources/Algorithms/Stride.swift
@@ -226,8 +226,8 @@ extension StrideCollection: Collection {
     offsetBy n: Int,
     limitedBy limit: Index
   ) -> Index? {
-    // We typically use the ternary operator but this significantly increases compile
-    // times when using Swift 5.3.2
+    // We typically use the ternary operator but this significantly increases
+    // compile times when using Swift 5.3.2
     // https://github.com/apple/swift-algorithms/issues/146
     let distance: Int
     if i == endIndex {

--- a/Sources/Algorithms/Stride.swift
+++ b/Sources/Algorithms/Stride.swift
@@ -226,9 +226,15 @@ extension StrideCollection: Collection {
     offsetBy n: Int,
     limitedBy limit: Index
   ) -> Index? {
-    let distance = i == endIndex
-      ? -((base.count - 1) % stride + 1) + (n - 1) * -stride
-      : n * -stride
+    // We typically use the ternary operator but this significantly increases compile
+    // times when using Swift 5.3.2
+    // https://github.com/apple/swift-algorithms/issues/146
+    let distance: Int
+    if i == endIndex {
+      distance = -((base.count - 1) % stride + 1) + (n - 1) * -stride
+    } else {
+      distance = n * -stride
+    }
     return base.index(
         i.base,
         offsetBy: distance,


### PR DESCRIPTION
### Description
Improve compile times for consumers using older versions of Xcode/swift. This change significantly improves compile times when using Swift 5.3.2. More details & benchmarks in #146 

*Edit* - Pushed a small change to the wording of the comment
