### PR TITLE
Add eager and lazy versions of `chunkedByReduction(into:_)`.

### DIFF
--- a/Guides/Chunked.md
+++ b/Guides/Chunked.md
@@ -3,8 +3,8 @@
 [[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Chunked.swift) | 
  [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/ChunkedTests.swift)]
 
-Break a collection into subsequences where consecutive elements pass a binary
-predicate, or where all elements in each chunk project to the same value. 
+Break a collection into subsequences where consecutive elements pass a binary or
+reducing predicate, or where all elements in each chunk project to the same value. 
 
 Also, includes a `chunks(ofCount:)` that breaks a collection into subsequences 
 of a given `count`.
@@ -18,6 +18,20 @@ you can chunk a collection into ascending sequences using this method:
 let numbers = [10, 20, 30, 10, 40, 40, 10, 20]
 let chunks = numbers.chunked(by: { $0 <= $1 })
 // [[10, 20, 30], [10, 40, 40], [10, 20]]
+```
+
+`chunkedByReduction(into:_)` uses a reducing predicate to chunk the base collection
+into subsequences of elements that reduce to a value for which the predicate returns `true`.
+For example, you can chunk a collection of numbers into sequences whose sum does not
+exceed some maximum value.
+
+```swift
+let numbers = [16, 8, 8, 19, 12, 5]
+let chunks = numbers.chunkedByReduction(into: 0) { sum, n in
+  sum += n
+  return sum <= 16
+}
+// [[16], [8, 8], [19], [12], [5]]
 ```
 
 The `chunk(on:)` method, by contrast, takes a projection of each element and

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -704,8 +704,8 @@ extension LazyCollectionProtocol {
   /// Lazily returns a collection of subsequences of this collection, chunked by
   /// the given reducing predicate.
   ///
-  ///
-  /// This example shows how to lazily chunk a list of integers into subsequences that sum to no more than 16.
+  /// This example shows how to lazily chunk a list of integers into
+  /// subsequences that sum to no more than 16.
   ///
   ///     let chunks = [16, 8, 8, 19, 12, 5].lazy.chunkedByReduction(into: 0) { sum, n in
   ///       sum += n
@@ -745,7 +745,8 @@ extension Collection {
   /// Eagerly returns a collection of subsequences of this collection, chunked by
   /// the given reducing predicate.
   ///
-  /// For example, to chunk a list of integers into subsequences that sum to no more than 16:
+  /// This example shows how to lazily chunk a list of integers into
+  /// subsequences that sum to no more than 16.
   ///
   ///     let chunks = [16, 8, 8, 19, 12, 5].chunkedByReduction(into: 0) { sum, n in
   ///       sum += n

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -579,3 +579,213 @@ extension ChunkedByCount: LazySequenceProtocol
   where Base: LazySequenceProtocol {}
 extension ChunkedByCount: LazyCollectionProtocol
   where Base: LazyCollectionProtocol {}
+
+//===----------------------------------------------------------------------===//
+// lazy.chunkedByReduction(into:_)
+//===----------------------------------------------------------------------===//
+
+/// A collection that lazily chunks a base collection into subsequences using
+/// the given reducing predicate.
+///
+/// - Note: This type is the result of
+///
+///     x.chunkedByReduction(into:_)
+///
+///   where `x` conforms to `LazyCollectionProtocol`.
+public struct ChunkedByReduction<Accumulator, Base: Collection> {
+  /// The collection that this instance provides a view onto.
+  @usableFromInline
+  internal let base: Base
+
+  /// Initial value passed to the reducing predicate.
+  @usableFromInline
+  internal let initialValue: Accumulator
+
+  /// The reducing predicate function.
+  @usableFromInline
+  internal let predicate: (inout Accumulator, Base.Element) -> Bool
+
+  /// The precomputed start index.
+  @usableFromInline
+  internal var _startIndex: Index
+
+  @inlinable
+  internal init(
+    base: Base,
+    initialValue: Accumulator,
+    predicate: @escaping (inout Accumulator, Base.Element) -> Bool
+  ) {
+    self.base = base
+    self.initialValue = initialValue
+    self.predicate = predicate
+
+    self._startIndex = Index(baseRange: base.startIndex..<base.startIndex)
+    if !base.isEmpty {
+      self._startIndex = indexForChunk(startingAt: base.startIndex)
+    }
+  }
+}
+
+extension ChunkedByReduction: LazyCollectionProtocol {
+  /// A position in a chunked collection.
+  public struct Index: Comparable {
+    /// The range of base collection elements corresponding to the chunk at this position.
+    @usableFromInline
+    internal let baseRange: Range<Base.Index>
+
+    @inlinable
+    internal init(baseRange: Range<Base.Index>) {
+      self.baseRange = baseRange
+    }
+
+    @inlinable
+    public static func == (lhs: Index, rhs: Index) -> Bool {
+      // Since each index represents the range of a disparate chunk, no two
+      // unique indices will have the same lower bound.
+      lhs.baseRange.lowerBound == rhs.baseRange.lowerBound
+    }
+
+    @inlinable
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      // Only use the lower bound to test for ordering, as above.
+      lhs.baseRange.lowerBound < rhs.baseRange.lowerBound
+    }
+  }
+
+  /// Returns the index in the chunked collection of the chunk starting at the given
+  /// base collection index.
+  @inlinable
+  internal func indexForChunk(
+    startingAt lowerBound: Base.Index
+  ) -> Index {
+    guard lowerBound < base.endIndex else { return endIndex }
+
+    var accumulator = initialValue
+    var i = lowerBound
+
+    while i != base.endIndex && predicate(&accumulator, base[i]) {
+      base.formIndex(after: &i)
+    }
+
+    if i == lowerBound { base.formIndex(after: &i) }
+
+    return Index(baseRange: lowerBound..<i)
+  }
+
+  @inlinable
+  public var startIndex: Index {
+    _startIndex
+  }
+
+  @inlinable
+  public var endIndex: Index {
+    Index(
+      baseRange: base.endIndex..<base.endIndex
+    )
+  }
+
+  @inlinable
+  public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Can't advance past endIndex")
+
+    return indexForChunk(startingAt: i.baseRange.upperBound)
+  }
+
+  @inlinable
+  public subscript(position: Index) -> Base.SubSequence {
+    precondition(position != endIndex, "Can't subscript using endIndex")
+    return base[position.baseRange]
+  }
+}
+
+extension ChunkedByReduction.Index: Hashable where Base.Index: Hashable {}
+
+extension LazyCollectionProtocol {
+  /// Lazily returns a collection of subsequences of this collection, chunked by
+  /// the given reducing predicate.
+  ///
+  ///
+  /// This example shows how to lazily chunk a list of integers into subsequences that sum to no more than 16.
+  ///
+  ///     let chunks = [16, 8, 8, 19, 12, 5].lazy.chunkedByReduction(into: 0) { sum, n in
+  ///       sum += n
+  ///       return sum <= 16
+  ///     }
+  ///
+  ///     for chunk in chunks {
+  ///       print(chunk)
+  ///     }
+  ///     // Prints:
+  ///     // [16]
+  ///     // [8, 8]
+  ///     // [19]
+  ///     // [12]
+  ///     // [5]
+  ///
+  /// Note that a single element which fails the predicate is included in the resulting collection.
+  ///
+  /// - Complexity: O(*n*), because the start index is pre-computed.
+  public func chunkedByReduction<Accumulator>(
+    into initialValue: Accumulator,
+    _ predicate: @escaping (inout Accumulator, Element) -> Bool
+  ) -> ChunkedByReduction<Accumulator, Self> {
+    ChunkedByReduction(
+      base: self,
+      initialValue: initialValue,
+      predicate: predicate
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// chunkedByReduction(into:_)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Eagerly returns a collection of subsequences of this collection, chunked by
+  /// the given reducing predicate.
+  ///
+  /// For example, to chunk a list of integers into subsequences that sum to no more than 16:
+  ///
+  ///     let chunks = [16, 8, 8, 19, 12, 5].chunkedByReduction(into: 0) { sum, n in
+  ///       sum += n
+  ///       return sum <= 16
+  ///     }
+  ///
+  ///     for chunk in chunks {
+  ///       print(chunk)
+  ///     }
+  ///     // Prints:
+  ///     // [16]
+  ///     // [8, 8]
+  ///     // [19]
+  ///     // [12]
+  ///     // [5]
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  public func chunkedByReduction<Accumulator>(
+    into initialValue: Accumulator,
+    _ predicate: @escaping (inout Accumulator, Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    guard !isEmpty else { return [] }
+
+    var result: [SubSequence] = []
+    var accumulator = initialValue
+    var start = startIndex
+    var i = start
+
+    while start < endIndex {
+      while try i != endIndex && predicate(&accumulator, self[i]) {
+        formIndex(after: &i)
+      }
+
+      if i == start { formIndex(after: &i) }
+
+      result.append(self[start..<i])
+      accumulator = initialValue
+      start = i
+    }
+
+    return result
+  }
+}


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description
I recently needed to separate a collection of UI objects into subsequences whose width did not exceed some maximum width, so they could be wrapped into rows. This seemed like a job for a chunking algorithm where the predicate would be allowed to reduce the elements, so I wrote that. I'm wondering whether others think it's generally useful enough to be included here.

Here's a simple example:

```swift
let numbers = [16, 8, 8, 19, 12, 5]
let chunks = numbers.chunkedByReduction(into: 0) { sum, n in
  sum += n
  return sum <= 16
}
// [[16], [8, 8], [19], [12], [5]]
```

Note that a single element which fails the predicate is included in the resulting collection. More on that below.

This sort of chunking could be implemented by the Standard Library's existing `reduce(into:_)`, but in that case the trailing closure would be cluttered with all the logic to keep track of and generate the subsequences. I like that this new method abstracts that away so the closure is simply the predicate that determines how to chunk elements.

### Detailed Design
I've added

```swift
extension Collection {
  public func chunkedByReduction<Accumulator>(
    into initialValue: Accumulator,
    _ predicate: @escaping (inout Accumulator, Element) throws -> Bool
  ) rethrows -> [SubSequence]
```

and

```swift
extension LazyCollectionProtocol {
  public func chunkedByReduction<Accumulator>(
    into initialValue: Accumulator,
    _ predicate: @escaping (inout Accumulator, Element) -> Bool
  ) -> ChunkedByReduction<Accumulator, Self>
```

#### Handling single elements which fail the predicate
In my UI problem which motivated this, it so happened that no UI element could exceed the width of the view I needed to wrap them into. But it wouldn't be the case in general that a single element would be guaranteed not to fail the predicate. The current implementation includes such elements in the result, to satisfy the property shared by all the other chunking methods that the entire base collection is included in their result.

### Documentation Plan
I updated [Chunked.md](Guides/Chunked.md) with a description and example of the new method.

### Test Plan
I added a series of tests for both the eager and lazy versions of the new method.

### Source Impact
This only adds API. No existing API is changed or removed.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
