### PR TITLE
Split a collection using a collection separator

### DIFF
--- a/Sources/Algorithms/FirstRange.swift
+++ b/Sources/Algorithms/FirstRange.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// firstRange(of:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  @inlinable
+  public func firstRange<Other: Collection>(
+    of other: Other,
+    by areEquivalent: (Element, Other.Element) throws -> Bool
+  ) rethrows -> Range<Index>? {
+    var searchStart = startIndex
+    
+    guard let needleFirst = other.first else {
+      return searchStart..<searchStart
+    }
+
+    while let matchStart = try self[searchStart...]
+            .firstIndex(where: { try areEquivalent($0, needleFirst) })
+    {
+      var index = matchStart
+      var otherIndex = other.startIndex
+
+      repeat {
+        formIndex(after: &index)
+        other.formIndex(after: &otherIndex)
+        
+        if otherIndex == other.endIndex {
+          return matchStart..<index
+        } else if index == endIndex {
+          return nil
+        }
+      } while try areEquivalent(self[index], other[otherIndex])
+
+      searchStart = self.index(after: matchStart)
+    }
+
+    return nil
+  }
+}
+
+extension Collection where Element: Equatable {
+  @inlinable
+  public func firstRange<Other: Collection>(of other: Other) -> Range<Index>?
+    where Other.Element == Element
+  {
+    firstRange(of: other, by: ==)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// lastRange(of:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+  @inlinable
+  public func lastRange<Other: BidirectionalCollection>(
+    of other: Other,
+    by areEquivalent: (Element, Other.Element) throws -> Bool
+  ) rethrows -> Range<Index>? {
+    var searchEnd = endIndex
+    
+    guard let otherLastIndex = other.indices.last else {
+      return searchEnd..<searchEnd
+    }
+    
+    let needleLast = other[otherLastIndex]
+
+    while let matchEnd = try self[..<searchEnd]
+            .lastIndex(where: { try areEquivalent($0, needleLast) })
+    {
+      var index = matchEnd
+      var otherIndex = otherLastIndex
+
+      repeat {
+        if otherIndex == other.startIndex {
+          return index..<self.index(after: matchEnd)
+        } else if index == startIndex {
+          return nil
+        }
+
+        formIndex(before: &index)
+        other.formIndex(before: &otherIndex)
+      } while try areEquivalent(self[index], other[otherIndex])
+
+      searchEnd = matchEnd
+    }
+
+    return nil
+  }
+}
+
+extension BidirectionalCollection where Element: Equatable {
+  @inlinable
+  public func lastRange<Other: BidirectionalCollection>(
+    of other: Other
+  ) -> Range<Index>? where Other.Element == Element {
+    lastRange(of: other, by: ==)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// contains(_:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  @inlinable
+  public func contains<Other: Collection>(
+    _ other: Other,
+    by areEquivalent: (Element, Other.Element) throws -> Bool
+  ) rethrows -> Bool {
+    try firstRange(of: other, by: areEquivalent) != nil
+  }
+}
+
+extension Collection where Element: Equatable {
+  @inlinable
+  public func contains<Other: Collection>(
+    _ other: Other
+  ) -> Bool where Other.Element == Element {
+    contains(other, by: ==)
+  }
+}

--- a/Sources/Algorithms/Split.swift
+++ b/Sources/Algorithms/Split.swift
@@ -1,0 +1,286 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public struct SplitCollection<
+  Base: Collection,
+  Separator: Collection
+> {
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let separator: Separator
+  
+  @usableFromInline
+  internal let maxSplits: Int
+
+  @usableFromInline
+  internal let omittingEmptySubsequences: Bool
+  
+  @usableFromInline
+  let areEquivalent: (Base.Element, Separator.Element) -> Bool
+  
+  @usableFromInline
+  internal var _startIndex: Index
+  
+  @usableFromInline
+  internal init(
+    base: Base,
+    separator: Separator,
+    maxSplits: Int,
+    omittingEmptySubsequences: Bool,
+    areEquivalent: @escaping (Base.Element, Separator.Element) -> Bool
+  ) {
+    self.base = base
+    self.separator = separator
+    self.maxSplits = maxSplits
+    self.omittingEmptySubsequences = omittingEmptySubsequences
+    self.areEquivalent = areEquivalent
+    
+    // Initialize the `_startIndex` property to be able to call the
+    // `index(after:splits:)` instance method.
+    _startIndex = Index(representation: .endIndex)
+    _startIndex = index(after: base.startIndex, splits: 0)
+  }
+}
+
+extension SplitCollection: Collection {
+  public struct Index {
+    @usableFromInline
+    internal enum Representation {
+      case index(
+        offset: Int,
+        baseRange: Range<Base.Index>,
+        separatorEnd: Base.Index?)
+      case endIndex
+    }
+    
+    @usableFromInline
+    internal let representation: Representation
+    
+    @inlinable
+    internal init(representation: Representation) {
+      self.representation = representation
+    }
+  }
+  
+  @inlinable
+  internal func index(after lowerBound: Base.Index, splits: Int) -> Index {
+    func indexFromRange(
+      _ range: Range<Base.Index>,
+      separatorEnd: Base.Index?
+    ) -> Index? {
+      if range.isEmpty && omittingEmptySubsequences {
+        return nil
+      } else {
+        return Index(representation: .index(
+          offset: splits,
+          baseRange: range,
+          separatorEnd: separatorEnd))
+      }
+    }
+    
+    var rangeStart = lowerBound
+    
+    if splits != maxSplits {
+      while let separatorRange = base[rangeStart...]
+              .firstRange(of: separator, by: areEquivalent)
+      {
+        let range = rangeStart..<separatorRange.lowerBound
+        rangeStart = separatorRange.upperBound
+        
+        if let index = indexFromRange(range, separatorEnd: rangeStart) {
+          return index
+        }
+      }
+    }
+    
+    return indexFromRange(rangeStart..<base.endIndex, separatorEnd: nil)
+      ?? endIndex
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    _startIndex
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(representation: .endIndex)
+  }
+  
+  @inlinable
+  public func index(after index: Index) -> Index {
+    switch index.representation {
+    case .index(let offset, _, let separatorEnd?):
+      return self.index(after: separatorEnd, splits: offset + 1)
+    case .index(_, _, nil):
+      return endIndex
+    case .endIndex:
+      fatalError("Can't advance past endIndex")
+    }
+  }
+  
+  @inlinable
+  public subscript(index: Index) -> Base.SubSequence {
+    switch index.representation {
+    case .index(_, let baseRange, _):
+      return base[baseRange]
+    case .endIndex:
+      fatalError("Can't subscript using endIndex")
+    }
+  }
+}
+
+extension SplitCollection.Index.Representation: Comparable, Hashable {
+  @inlinable
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.index(let lhs, _, _), .index(let rhs, _, _)):
+      return lhs == rhs
+    case (.endIndex, .endIndex):
+      return true
+    case (.index, .endIndex), (.endIndex, .index):
+      return false
+    }
+  }
+  
+  @inlinable
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.endIndex, _):
+      return false
+    case (_, .endIndex):
+      return true
+    case (.index(let lhs, _, _), .index(let rhs, _, _)):
+      return lhs < rhs
+    }
+  }
+  
+  @inlinable
+  func hash(into hasher: inout Hasher) {
+    switch self {
+    case .index(let offset, _, _):
+      hasher.combine(offset)
+    case .endIndex:
+      hasher.combine(Int.max)
+    }
+  }
+}
+
+extension SplitCollection.Index: Comparable, Hashable {
+  @inlinable
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.representation == rhs.representation
+  }
+
+  @inlinable
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.representation < rhs.representation
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// split(separator:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  @inlinable
+  public func split<Separator: Collection>(
+    separator: Separator,
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true,
+    by areEquivalent: (Element, Separator.Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    precondition(maxSplits >= 0, "Must take zero or more splits")
+    precondition(!separator.isEmpty)
+    
+    var index = startIndex
+    var result: [SubSequence] = []
+    
+    func append(upTo end: Index) {
+      if !omittingEmptySubsequences || index != end {
+        result.append(self[index..<end])
+      }
+    }
+    
+    while result.count != maxSplits, let range = try self[index...]
+            .firstRange(of: separator, by: areEquivalent)
+    {
+      append(upTo: range.lowerBound)
+      index = range.upperBound
+    }
+    
+    append(upTo: endIndex)
+    return result
+  }
+}
+
+extension Collection where Element: Equatable {
+  @inlinable
+  @_disfavoredOverload // To make sure the element separator version is
+                       // preferred when a string literal is used
+  public func split<Separator: Collection>(
+    separator: Separator,
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true
+  ) -> SplitCollection<Self, Separator>
+    where Separator.Element == Element
+  {
+    SplitCollection(
+      base: self,
+      separator: separator,
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences,
+      areEquivalent: ==)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// lazy.split(separator:)
+//===----------------------------------------------------------------------===//
+
+extension LazyCollectionProtocol {
+  @inlinable
+  public func split<Separator: Collection>(
+    separator: Separator,
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true,
+    by areEquivalent: @escaping (Element, Separator.Element) -> Bool
+  ) -> LazyCollection<SplitCollection<Elements, Separator>> {
+    SplitCollection(
+      base: elements,
+      separator: separator,
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences,
+      areEquivalent: areEquivalent
+    ).lazy
+  }
+}
+
+extension LazyCollectionProtocol where Element: Equatable {
+  @inlinable
+  public func split<Separator: Collection>(
+    separator: Separator,
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true
+  ) -> LazyCollection<SplitCollection<Elements, Separator>>
+    where Separator.Element == Element
+  {
+    SplitCollection(
+      base: elements,
+      separator: separator,
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences,
+      areEquivalent: ==
+    ).lazy
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/FirstRangeTests.swift
+++ b/Tests/SwiftAlgorithmsTests/FirstRangeTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class FirstRangeTests: XCTestCase {
+  func test() {
+    let array = [0, 1, 2, 1, 2, 1, 2, 3]
+    
+    XCTAssertEqual(array.firstRange(of: [0, 1, 2]),       0..<3)
+    XCTAssertEqual(array.firstRange(of: [1, 2]),          1..<3)
+    XCTAssertEqual(array.firstRange(of: [1, 2, 3]),       5..<8)
+    XCTAssertEqual(array.firstRange(of: [1, 2, 1, 2, 3]), 3..<8)
+    XCTAssertNil(array.firstRange(of: [0, 1, 2, 3]))
+    
+    XCTAssertEqual(array.lastRange(of: [1, 2]),          5..<7)
+    XCTAssertEqual(array.lastRange(of: [0, 1, 2]),       0..<3)
+    XCTAssertEqual(array.lastRange(of: [0, 1, 2, 1, 2]), 0..<5)
+    XCTAssertNil(array.lastRange(of: [0, 1, 2, 3]))
+  }
+  
+  func testEmpty() {
+    let array = [0, 1, 2, 1, 2, 1, 2, 3]
+    let empty: [Int] = []
+    
+    XCTAssertEqual(array.firstRange(of: empty), 0..<0)
+    XCTAssertEqual(empty.firstRange(of: empty), 0..<0)
+    XCTAssertNil(empty.firstRange(of: array))
+    
+    XCTAssertEqual(array.lastRange(of: empty), 8..<8)
+    XCTAssertEqual(empty.lastRange(of: empty), 0..<0)
+    XCTAssertNil(empty.lastRange(of: array))
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/SplitTests.swift
+++ b/Tests/SwiftAlgorithmsTests/SplitTests.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class SplitTests: XCTestCase {
+  func test() {
+    XCTAssertEqual(
+      "foo, bar, baz".split(separator: ", ", by: ==),
+      ["foo", "bar", "baz"])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", by: ==),
+      ["foo", "bar", "baz"])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 2, by: ==),
+      ["foo", "bar", "baz, "])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 1, by: ==),
+      ["foo", "bar, baz, "])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 0, by: ==),
+      [", foo, bar, baz, "])
+
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", omittingEmptySubsequences: false, by: ==),
+      ["", "foo", "bar", "baz", ""])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 4, omittingEmptySubsequences: false, by: ==),
+      ["", "foo", "bar", "baz", ""])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 3, omittingEmptySubsequences: false, by: ==),
+      ["", "foo", "bar", "baz, "])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 2, omittingEmptySubsequences: false, by: ==),
+      ["", "foo", "bar, baz, "])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 1, omittingEmptySubsequences: false, by: ==),
+      ["", "foo, bar, baz, "])
+    XCTAssertEqual(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 0, omittingEmptySubsequences: false, by: ==),
+      [", foo, bar, baz, "])
+  }
+  
+  func testLazy() {
+    XCTAssertEqualSequences(
+      "foo, bar, baz".split(separator: ", "),
+      ["foo", "bar", "baz"])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", "),
+      ["foo", "bar", "baz"])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 2),
+      ["foo", "bar", "baz, "])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 1),
+      ["foo", "bar, baz, "])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 0),
+      [", foo, bar, baz, "])
+    
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", omittingEmptySubsequences: false),
+      ["", "foo", "bar", "baz", ""])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 4, omittingEmptySubsequences: false),
+      ["", "foo", "bar", "baz", ""])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 3, omittingEmptySubsequences: false),
+      ["", "foo", "bar", "baz, "])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 2, omittingEmptySubsequences: false),
+      ["", "foo", "bar, baz, "])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 1, omittingEmptySubsequences: false),
+      ["", "foo, bar, baz, "])
+    XCTAssertEqualSequences(
+      ", foo, bar, baz, ".split(separator: ", ", maxSplits: 0, omittingEmptySubsequences: false),
+      [", foo, bar, baz, "])
+  }
+}


### PR DESCRIPTION
Depends on #154.

Note that the overload on `LazyCollectionProtocol` returns a `LazyCollection<SplitCollection<Elements, Separator>>` rather than a `SplitCollection<Self, Separator>`. The purpose of this is to have it return slices of the underlying collection, rather than slices of the lazy wrapper.

We'll also need to unify the name of the type added here (currently `SplitCollection`) with the type returned by the lazy `split` operation that takes a single element separator (currently `LazySplitCollection`).

```swift
extension Collection {
  public func split<Separator: Collection>(
    separator: Separator,
    maxSplits: Int = Int.max,
    omittingEmptySubsequences: Bool = true,
    by areEquivalent: (Element, Separator.Element) throws -> Bool
  ) rethrows -> [SubSequence]
}

extension Collection where Element: Equatable {
  public func split<Separator: Collection>(
    separator: Separator,
    maxSplits: Int = Int.max,
    omittingEmptySubsequences: Bool = true
  ) -> SplitCollection<Self, Separator>
    where Separator.Element == Element
}

extension LazyCollectionProtocol {
  public func split<Separator: Collection>(
    separator: Separator,
    maxSplits: Int = Int.max,
    omittingEmptySubsequences: Bool = true,
    by areEquivalent: @escaping (Element, Separator.Element) -> Bool
  ) -> LazyCollection<SplitCollection<Elements, Separator>>
}

extension LazyCollectionProtocol where Element: Equatable {
  public func split<Separator: Collection>(
    separator: Separator,
    maxSplits: Int = Int.max,
    omittingEmptySubsequences: Bool = true
  ) -> LazyCollection<SplitCollection<Elements, Separator>>
    where Separator.Element == Element
}
```

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
