### PR TITLE
Ensure `chunked(by:)` always compares consecutive elements

### DIFF
--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -78,6 +78,25 @@ final class ChunkedTests: XCTestCase {
     validateIndexTraversals(lazyChunks)
   }
   
+  func testChunkedByComparesConsecutiveElements() {
+    XCTAssertEqualSequences(
+      [1, 2, 3, 4, 6, 7, 8, 9].chunked(by: { $1 - $0 == 1 }),
+      [[1, 2, 3, 4], [6, 7, 8, 9]])
+    
+    XCTAssertEqualSequences(
+      [1, 2, 3, 4, 6, 7, 8, 9].lazy.chunked(by: { $1 - $0 == 1 }),
+      [[1, 2, 3, 4], [6, 7, 8, 9]])
+    
+    print(Array([1, 2, 3].lazy.chunked(by: { $1 - $0 == 1 })))
+    print(Array([1, 2, 3].lazy.chunked(by: { $1 - $0 == 1 }).reversed()))
+    
+    XCTAssertEqualSequences(
+      [1, 2, 3, 4, 6, 7, 8, 9].lazy.chunked(by: { $1 - $0 == 1 }).reversed(),
+      [[6, 7, 8, 9], [1, 2, 3, 4]])
+    
+    validateIndexTraversals([1, 2, 3].lazy.chunked(by: { $1 - $0 == 1 }))
+  }
+  
   func testChunkedLazy() {
     XCTAssertLazySequence(fruits.lazy.chunked(by: { $0.first == $1.first }))
     XCTAssertLazySequence(fruits.lazy.chunked(on: { $0.first }))


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Fixes #161.

```swift
[a, b, c, d].chunked(by: { print($0, $1); return true })
// previous behavior: (a, b), (a, c), (a, d)
// correct behavior:  (a, b), (b, c), (c, d)
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
