### PR TITLE
Make Algorithms depend on Numerics product instead of RealModule.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .target(
             name: "Algorithms",
             dependencies: [
-              .product(name: "RealModule", package: "swift-numerics"),
+              .product(name: "Numerics", package: "swift-numerics"),
             ]),
         .testTarget(
             name: "SwiftAlgorithmsTests",


### PR DESCRIPTION
The RealModule _library product_ will be removed from Numerics at some future point (the _module_ will continue to exist). Update Package.swift to depend on the Numerics library instead.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
