### PR TITLE
[Rotate] Modify API of rotate(subrange:) to take an arbitrary range expression

### DIFF
--- a/Guides/Rotate.md
+++ b/Guides/Rotate.md
@@ -24,6 +24,15 @@ numbers.rotate(subrange: 3..<6, toStartAt: 4)
 // numbers = [20, 30, 10, 50, 60, 40]
 ```
 
+The examples above can also be expressed with other range expressions:
+```swift
+var numbers = [10, 20, 30, 40, 50, 60]
+numbers.rotate(subrange: ..<3, toStartAt: 1)
+// numbers = [20, 30, 10, 40, 50, 60]
+numbers.rotate(subrange: 3..., toStartAt: 4)
+// numbers = [20, 30, 10, 50, 60, 40]
+```
+
 ## Detailed Design
 
 This adds the two `MutableCollection` methods shown above:

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -140,9 +140,9 @@ extension MutableCollection {
     subrange: Range,
     toStartAt newStart: Index
   ) -> Index where Range.Bound == Index {
-    let cSubrange = subrange.relative(to: self)
-    var m = newStart, s = cSubrange.lowerBound
-    let e = cSubrange.upperBound
+    let relativeSubrange = subrange.relative(to: self)
+    var m = newStart, s = relativeSubrange.lowerBound
+    let e = relativeSubrange.upperBound
     
     // Handle the trivial cases
     if s == m { return e }
@@ -249,10 +249,10 @@ extension MutableCollection where Self: BidirectionalCollection {
     subrange: Range,
     toStartAt newStart: Index
   ) -> Index where Range.Bound == Index {
-    let cSubrange = subrange.relative(to: self)
-    reverse(subrange: cSubrange.lowerBound..<newStart)
-    reverse(subrange: newStart..<cSubrange.upperBound)
-    let (p, q) = _reverse(subrange: cSubrange, until: newStart)
+    let relativeSubrange = subrange.relative(to: self)
+    reverse(subrange: relativeSubrange.lowerBound..<newStart)
+    reverse(subrange: newStart..<relativeSubrange.upperBound)
+    let (p, q) = _reverse(subrange: relativeSubrange, until: newStart)
     reverse(subrange: p..<q)
     return newStart == p ? q : p
   }

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -132,15 +132,17 @@ extension MutableCollection {
   /// - Returns: The new index of the element that was at the start of
   ///   `subrange` pre-rotation.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of `subrange`.
+  /// - Complexity: O(*n*), where *n* is the length of `subrange` relative to
+  ///   this collection.
   @inlinable
   @discardableResult
-  public mutating func rotate(
-    subrange: Range<Index>,
+  public mutating func rotate<Range: RangeExpression>(
+    subrange: Range,
     toStartAt newStart: Index
-  ) -> Index {
-    var m = newStart, s = subrange.lowerBound
-    let e = subrange.upperBound
+  ) -> Index where Range.Bound == Index {
+    let cSubrange = subrange.relative(to: self)
+    var m = newStart, s = cSubrange.lowerBound
+    let e = cSubrange.upperBound
     
     // Handle the trivial cases
     if s == m { return e }
@@ -239,16 +241,18 @@ extension MutableCollection where Self: BidirectionalCollection {
   /// - Returns: The new index of the element that was at the start of
   ///   `subrange` pre-rotation.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of `subrange`.
+  /// - Complexity: O(*n*), where *n* is the length of `subrange` relative to
+  ///   this collection.
   @inlinable
   @discardableResult
-  public mutating func rotate(
-    subrange: Range<Index>,
+  public mutating func rotate<Range: RangeExpression>(
+    subrange: Range,
     toStartAt newStart: Index
-  ) -> Index {
-    reverse(subrange: subrange.lowerBound..<newStart)
-    reverse(subrange: newStart..<subrange.upperBound)
-    let (p, q) = _reverse(subrange: subrange, until: newStart)
+  ) -> Index where Range.Bound == Index {
+    let cSubrange = subrange.relative(to: self)
+    reverse(subrange: cSubrange.lowerBound..<newStart)
+    reverse(subrange: newStart..<cSubrange.upperBound)
+    let (p, q) = _reverse(subrange: cSubrange, until: newStart)
     reverse(subrange: p..<q)
     return newStart == p ? q : p
   }

--- a/Tests/SwiftAlgorithmsTests/RotateTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RotateTests.swift
@@ -64,6 +64,34 @@ final class RotateTests: XCTestCase {
     XCTAssertEqual(numbers[oldStart], 10)
   }
   
+  func testRotateSubrangeClosed() {
+    var numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let oldStart = numbers.rotate(subrange: 0...3, toStartAt: 2)
+    XCTAssertEqual(numbers, [30, 40, 10, 20, 50, 60, 70, 80])
+    XCTAssertEqual(numbers[oldStart], 10)
+  }
+  
+  func testRotateSubrangePartialUpTo() {
+    var numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let oldStart = numbers.rotate(subrange: ..<4, toStartAt: 2)
+    XCTAssertEqual(numbers, [30, 40, 10, 20, 50, 60, 70, 80])
+    XCTAssertEqual(numbers[oldStart], 10)
+  }
+  
+  func testRotateSubrangePartialUpThrough() {
+    var numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let oldStart = numbers.rotate(subrange: ...3, toStartAt: 2)
+    XCTAssertEqual(numbers, [30, 40, 10, 20, 50, 60, 70, 80])
+    XCTAssertEqual(numbers[oldStart], 10)
+  }
+  
+  func testRotateSubrangePartialRangeFrom() {
+    var numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let oldStart = numbers.rotate(subrange: 2..., toStartAt: 3)
+    XCTAssertEqual(numbers, [10, 20, 40, 50, 60, 70, 80, 30])
+    XCTAssertEqual(numbers[oldStart], 30)
+  }
+  
   /// Tests the example given in `rotate(toStartAt:)`’s documentation
   func testRotateExample() {
     var numbers = [10, 20, 30, 40, 50, 60, 70, 80]


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Just throwing the idea here, maybe would be nice to be able to call this API with any kind of range. 
And since is not a source breaking change, I thought it was worth bring to discussion. 

cc @natecook1000 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
