### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Finally, add `import Algorithms` to your source code.
 
 ## Source Stability
 
-The Swift Numerics package is source stable; version numbers follow [Semantic Versioning](https://semver.org/). Source breaking changes to public API can only land in a new major version.
+The Swift Algorithms package is source stable; version numbers follow [Semantic Versioning](https://semver.org/). Source breaking changes to public API can only land in a new major version.
 
 The public API of version 1.0 of the `swift-algorithms` package consists of non-underscored declarations that are marked `public` in the `Algorithms` module. Interfaces that aren't part of the public API may continue to change in any release, including patch releases.
 


### PR DESCRIPTION
The readme mistakenly refers to "Swift Numerics" in one place. Looks like a copy/paste oversight introduced in #167.

### Checklist
- [ ] (n/a) I've added at least one test that validates that my change is working, if appropriate
- [ ] (n/a) I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
