### PR TITLE
Clarify `endIndex` behavior of `partitioningIndex(where:)` in documentation (Resolves #170)

### DIFF
--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -179,7 +179,8 @@ extension Collection {
   /// - Parameter belongsInSecondPartition: A predicate that partitions the
   ///   collection.
   /// - Returns: The index of the first element in the collection for which
-  ///   `predicate` returns `true`.
+  ///   `predicate` returns `true`, or `endIndex` if there are no elements
+  ///   for which `predicate` returns `true`.
   ///
   /// - Complexity: O(log *n*), where *n* is the length of this collection if
   ///   the collection conforms to `RandomAccessCollection`, otherwise O(*n*).

--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -168,8 +168,8 @@ extension MutableCollection where Self: BidirectionalCollection {
 //===----------------------------------------------------------------------===//
 
 extension Collection {
-  /// Returns the index of the first element in the collection that matches
-  /// the predicate.
+  /// Returns the start index of the partition of a collection that matches
+  /// the given predicate.
   ///
   /// The collection must already be partitioned according to the predicate.
   /// That is, there should be an index `i` where for every element in

--- a/Tests/SwiftAlgorithmsTests/PartitionTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PartitionTests.swift
@@ -102,6 +102,16 @@ final class PartitionTests: XCTestCase {
     XCTAssertEqual(b, input.endIndex)
   }
   
+  func testPartitioningIndexWithOneEmptyPartition() {
+    let input: Range<Int> = (0 ..< 10)
+    
+    let a = input.partitioningIndex(where: { $0 > 10 })
+    XCTAssertEqual(a, input.endIndex)
+    
+    let b = input.partitioningIndex(where: { $0 >= 0 })
+    XCTAssertEqual(b, input.startIndex)
+  }
+  
   func testPartitionWithSubrangeBidirectionalCollection() {
     for length in 10...20 {
       let a = Array(0..<length)

--- a/Tests/SwiftAlgorithmsTests/PartitionTests.swift
+++ b/Tests/SwiftAlgorithmsTests/PartitionTests.swift
@@ -92,6 +92,16 @@ final class PartitionTests: XCTestCase {
     }
   }
   
+  func testPartitioningIndexWithEmptyInput() {
+    let input: [Int] = []
+    
+    let a = input.partitioningIndex(where: { _ in return true })
+    XCTAssertEqual(a, input.startIndex)
+    
+    let b = input.partitioningIndex(where: { _ in return false })
+    XCTAssertEqual(b, input.endIndex)
+  }
+  
   func testPartitionWithSubrangeBidirectionalCollection() {
     for length in 10...20 {
       let a = Array(0..<length)


### PR DESCRIPTION
Resolves https://github.com/apple/swift-algorithms/issues/170

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
