### PR TITLE
`min(count:…)` implementation: Remove the last element before determining the insertion index

### DIFF
--- a/Sources/Algorithms/MinMax.swift
+++ b/Sources/Algorithms/MinMax.swift
@@ -28,11 +28,9 @@ extension Sequence {
     while let e = iterator.next() {
       // To be part of `result`, `e` must be strictly less than `result.last`.
       guard try areInIncreasingOrder(e, result.last!) else { continue }
+      result.removeLast()
       let insertionIndex =
         try result.partitioningIndex { try areInIncreasingOrder(e, $0) }
-      
-      assert(insertionIndex != result.endIndex)
-      result.removeLast()
       result.insert(e, at: insertionIndex)
     }
 


### PR DESCRIPTION
Previously, in `_minImplementation(count:sortedBy:)`, when finding a new, smaller element, we were calculating the insertion index on the full-sized collection, subsequently removing the last element, then inserting the new element at that insertion index. This has a couple small problems:
1. We were calling `partitioningIndex(where:)` on a larger collection than necessary. By removing the last element first (which doesn’t need to be compared against again), we make the collection slightly smaller, resulting in fewer comparisons. For simple comparisons (like `Int`s), this isn’t a big deal, but if the comparison is more expensive (like with a custom struct with multiple properties), this can make a slight difference.

2. The insertion index that we found could theoretically be invalidated after calling `removeLast()`, according to the [documentation](https://developer.apple.com/documentation/swift/array/2885764-removelast#discussion):
    
    > Calling this method may invalidate all saved indices of this collection. Do not rely on a previously stored index value after altering a collection with any operation that can change its length.
    
    While this isn’t currently/ever going to be a problem for `Array`, it‘s still good practice. This could theoretically set us up in the future to use a more optimized data structure with different indexing behavior than `Array`.

Neither of these are real big issues, but I stumbled upon this today and thought it a small worthwhile change.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
