### PR TITLE
Add @discardableResult attribute to stablePartition

### DIFF
--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -58,6 +58,7 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n* log *n*), where *n* is the length of this collection.
   @inlinable
+  @discardableResult
   public mutating func stablePartition(
     subrange: Range<Index>,
     by belongsInSecondPartition: (Element) throws-> Bool
@@ -78,6 +79,7 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n* log *n*), where *n* is the length of this collection.
   @inlinable
+  @discardableResult
   public mutating func stablePartition(
     by belongsInSecondPartition: (Element) throws-> Bool
   ) rethrows -> Index {


### PR DESCRIPTION
- [x] I've completed this task
- [ ] This task isn't completed

Since stablePartition is used frequently in contexts where it's return result isn't needed, I added @discardableResult attribute to both public methods for stablePartition to avoid Xcode's warning about unused result of call to stablePartition. 

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
