### PR TITLE
[Rotate] Non-mutating variants for rotating APIs

### DIFF
--- a/Guides/Rotate.md
+++ b/Guides/Rotate.md
@@ -24,6 +24,18 @@ numbers.rotate(subrange: 3..<6, toStartAt: 4)
 // numbers = [20, 30, 10, 50, 60, 40]
 ```
 
+We also provide non-mutating variants of `rotate(toStartAt:)` and `rotate(subrange:toStartAt:)` 
+that are `rotated(toStartAt:)` and `rotated(subrange:toStartAt:)` respectively and results in 
+a `RotatedCollection` view that presents the elements of a `base` collection rotated. 
+
+```swift
+var numbers = [10, 20, 30, 40, 50, 60]
+let first = numbers.rotated(subrange: 0..<3, toStartAt: 1)
+// first = [20, 30, 10, 40, 50, 60]
+let second = numbers.rotate(subrange: 3..<6, toStartAt: 4)
+// second = [20, 30, 10, 50, 60, 40]
+```
+
 ## Detailed Design
 
 This adds the two `MutableCollection` methods shown above:
@@ -39,12 +51,28 @@ extension MutableCollection {
 }
 ```
 
+For the non-mutating variants 
+```swift
+extension Collection {
+    func rotated(toStartAt p: Index) -> RotatedCollection<Self>
+
+    func rotated(
+        subrange: Range<Index>,
+        toStartAt p: Index
+    ) -> RotatedCollection<Self>
+}
+```
+
 ### Complexity
 
 Rotation is a O(_n_) operation, where _n_ is the length of the range being
 rotated. The `BidirectionalCollection` version of rotation significantly lowers
 the number of swaps required per element, so `rotate` would need to be a
 `MutableCollection` customization point were it adopted by the standard library.
+
+The non-mutating variants are O(1) when `Base` collection conforms to `RandomAccessCollection`.
+Otherwise, O(_n_) where _n_ is the length of the range being rotated which is the length of the
+whole base collection for `func rotated(toStartAt p: Index) -> RotatedCollection<Self>`.
 
 ### Naming
 

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -313,7 +313,7 @@ public struct RotatedCollection<Base: Collection> {
     self.subrange = _subrange
     self.newStart = _newStart
 
-    // Pre-computed indexes and distance in order to calculate rotated
+    // Pre-computed indexes and distances in order to calculate rotated
     // position.
     self.newStartDistance = base.distance(from: subrange.lowerBound,
                                           to: newStart)
@@ -413,6 +413,7 @@ extension RotatedCollection {
   /// - Complexity: O(1) when `Base` conforms to `RandomAccessCollection`.
   /// Otherwise O(*n*), where *n* is the count of base collection.
   @inlinable
+  @inline(__always)
   public var count: Int { base.count }
 }
 
@@ -479,7 +480,9 @@ extension Collection {
       subrange.lowerBound >= startIndex && subrange.upperBound <= endIndex
     )
     return RotatedCollection(
-      _base: self, _subrange: subrange, _newStart: newStart
+      _base: self,
+      _subrange: subrange,
+      _newStart: newStart
     )
   }
 
@@ -510,7 +513,9 @@ extension Collection {
     toStartAt newStart: Index
   ) -> RotatedCollection<Self> {
     RotatedCollection(
-      _base: self, _subrange: startIndex..<endIndex, _newStart: newStart
+      _base: self,
+      _subrange: startIndex..<endIndex,
+      _newStart: newStart
     )
   }
 }

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -302,8 +302,9 @@ public struct RotatedCollection<Base: Collection> {
   @usableFromInline
   internal let lowerboundRotatedDistance: Int
 
-  /// - Complexity: O(1) when `Base` conforms to `RandomAccessCollection`.
-  /// Otherwise, O(*n*), where *n* is the count of the subrange.
+  /// - Complexity: O(1) when `Base` conforms to
+  /// `RandomAccessCollection`. Otherwise, O(*n*), where
+  /// *n* is the count of the `subrange`.
   @inlinable
   internal init(
     _base: Base, _subrange: Range<Base.Index>, _newStart: Base.Index
@@ -334,17 +335,19 @@ extension RotatedCollection: Collection {
     }
   }
 
+  /// - Complexity: O(1)
   @inlinable
   public var startIndex: Index {
     Index(_baseIndex: base.startIndex)
   }
 
+  /// - Complexity: O(1)
   @inlinable
   public var endIndex: Index {
     Index(_baseIndex: base.endIndex)
   }
 
-  /// - Complexity: O(1) if the collection conforms to
+  /// - Complexity: O(1) when `Base` conforms to
   /// `RandomAccessCollection`. Otherwise, O(*n*), where
   /// *n* is the count of the `subrange`.
   @inlinable

--- a/Sources/Algorithms/Rotate.swift
+++ b/Sources/Algorithms/Rotate.swift
@@ -118,7 +118,7 @@ extension MutableCollection {
   /// Rotating a collection is equivalent to breaking the collection into two
   /// sections at the index `newStart`, and then swapping those two sections.
   /// In this example, the `numbers` array is rotated so that the element at
-  /// index `3` (`40`) is first:
+  /// index `2` (`30`) is first:
   ///
   ///     var numbers = [10, 20, 30, 40, 50, 60, 70, 80]
   ///     let oldStart = numbers.rotate(subrange: 0..<4, toStartAt: 2)

--- a/Tests/SwiftAlgorithmsTests/RotateTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RotateTests.swift
@@ -86,4 +86,84 @@ final class RotateTests: XCTestCase {
       }
     }
   }
+
+//===----------------------------------------------------------------------===//
+// RotatedCollection Tests
+//===----------------------------------------------------------------------===//
+  
+  /// Tests  lazy `rotated(subrange:toStartAt:)` with an empty collection
+  func testLazyRotateSubrangeOnEmptyCollection() {
+    let numbers = [Int]()
+    let actual = numbers.rotated(subrange: 0..<0, toStartAt: 0)
+    XCTAssertEqualSequences(actual, [])
+  }
+  
+  /// Tests  lazy `rotated(subrange:toStartAt:)` with the full range of the collection
+  func testLazyRotatedFullRange() {
+    let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let actual = numbers.rotated(subrange: 0..<8, toStartAt: 1)
+    XCTAssertEqualSequences(actual, [20, 30, 40, 50, 60, 70, 80, 10])
+  }
+  
+  /// Tests the example given in lazy `rotated(subrange:toStartAt:)`’s documentation
+  func testLazyRotatedSubrange() {
+    let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let actual = numbers.rotated(subrange: 0..<4, toStartAt: 2)
+    XCTAssertEqualSequences(actual, [30, 40, 10, 20, 50, 60, 70, 80])
+  }
+  
+  /// Tests the example given in lazy `rotated(toStartAt:)`’s documentation
+  func testLazyRotatedExample() {
+    let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let actual = numbers.rotated(toStartAt: 3)
+    XCTAssertEqualSequences(actual, [40, 50, 60, 70, 80, 10, 20, 30])
+  }
+  
+  /// Tests the `RotatedCollection` bidirectional conformance.
+  func testLazyRotatedReversed() {
+    let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
+    let actual = numbers.rotated(toStartAt: 3)
+    XCTAssertEqualSequences(actual, [40, 50, 60, 70, 80, 10, 20, 30])
+    let reversed: ReversedCollection<RotatedCollection<[Int]>> = actual.reversed()
+    XCTAssertEqualSequences(reversed, [30, 20, 10, 80, 70, 60, 50, 40])
+  }
+  
+  /// Tests lazy `rotated(toStartAt:)` on collections of varying lengths, at different
+  /// starting points.
+  func testLazyRotated() {
+    for length in 0...15 {
+      let a = Array(0..<length)
+      var b = a
+      for j in 0..<length {
+        var origB = b
+        let i = b.rotate(toStartAt: j)
+        XCTAssertEqualSequences(a[j...] + a[..<j], b)
+        
+        var bRotated = origB.rotated(toStartAt: j)
+        // Lazy RotatedCollection of `b` produces same
+        // result as in-place rotation.
+        XCTAssertEqualSequences(b, bRotated)
+        
+        origB = b
+        b.rotate(toStartAt: i)
+        bRotated = origB.rotated(toStartAt: i)
+        // Assert that both in-place rotated and lazy
+        // RotatedCollection of `b` produces `a`.
+        XCTAssertEqual(a, b)
+        XCTAssertEqualSequences(a, bRotated)
+      }
+    }
+  }
+
+  /// Tests lazy `rotated(toStartAt:)` index traversals.
+  func testIndexTraversals() {
+    let validator = IndexValidator<RotatedCollection<[Int]>>()
+    for length in 0...15 {
+      let a = Array(0..<length)
+      for j in 0..<length {
+        let aRotated = a.rotated(toStartAt: j)
+        validator.validate(aRotated, expectedCount: length)
+      }
+    }
+  }
 }

--- a/Tests/SwiftAlgorithmsTests/RotateTests.swift
+++ b/Tests/SwiftAlgorithmsTests/RotateTests.swift
@@ -91,28 +91,30 @@ final class RotateTests: XCTestCase {
 // RotatedCollection Tests
 //===----------------------------------------------------------------------===//
   
-  /// Tests  lazy `rotated(subrange:toStartAt:)` with an empty collection
+  /// Tests lazy `rotated(subrange:toStartAt:)` with an empty collection
   func testLazyRotateSubrangeOnEmptyCollection() {
     let numbers = [Int]()
     let actual = numbers.rotated(subrange: 0..<0, toStartAt: 0)
     XCTAssertEqualSequences(actual, [])
   }
   
-  /// Tests  lazy `rotated(subrange:toStartAt:)` with the full range of the collection
+  /// Tests lazy `rotated(subrange:toStartAt:)` with the full range of the
+  /// collection.
   func testLazyRotatedFullRange() {
     let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
     let actual = numbers.rotated(subrange: 0..<8, toStartAt: 1)
     XCTAssertEqualSequences(actual, [20, 30, 40, 50, 60, 70, 80, 10])
   }
   
-  /// Tests the example given in lazy `rotated(subrange:toStartAt:)`’s documentation
+  /// Tests the example given in lazy `rotated(subrange:toStartAt:)`’s
+  /// documentation.
   func testLazyRotatedSubrange() {
     let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
     let actual = numbers.rotated(subrange: 0..<4, toStartAt: 2)
     XCTAssertEqualSequences(actual, [30, 40, 10, 20, 50, 60, 70, 80])
   }
   
-  /// Tests the example given in lazy `rotated(toStartAt:)`’s documentation
+  /// Tests the example given in lazy `rotated(toStartAt:)`’s documentation.
   func testLazyRotatedExample() {
     let numbers = [10, 20, 30, 40, 50, 60, 70, 80]
     let actual = numbers.rotated(toStartAt: 3)
@@ -128,29 +130,31 @@ final class RotateTests: XCTestCase {
     XCTAssertEqualSequences(reversed, [30, 20, 10, 80, 70, 60, 50, 40])
   }
   
-  /// Tests lazy `rotated(toStartAt:)` on collections of varying lengths, at different
-  /// starting points.
+  /// Tests lazy `rotated(toStartAt:)` on collections of varying lengths,
+  /// at different starting points.
   func testLazyRotated() {
     for length in 0...15 {
       let a = Array(0..<length)
       var b = a
       for j in 0..<length {
-        var origB = b
+        let bRotatedJ = b.rotated(toStartAt: j)
         let i = b.rotate(toStartAt: j)
         XCTAssertEqualSequences(a[j...] + a[..<j], b)
         
-        var bRotated = origB.rotated(toStartAt: j)
         // Lazy RotatedCollection of `b` produces same
         // result as in-place rotation.
-        XCTAssertEqualSequences(b, bRotated)
+        XCTAssertEqualSequences(b, bRotatedJ)
         
-        origB = b
         b.rotate(toStartAt: i)
-        bRotated = origB.rotated(toStartAt: i)
+        
+        // Test rotating a `RotatedCollection<[Int]>`
+        let iRotatedIdx = bRotatedJ.index(bRotatedJ.startIndex, offsetBy: i)
+        let bRotatedI = bRotatedJ.rotated(toStartAt: iRotatedIdx)
+        
         // Assert that both in-place rotated and lazy
-        // RotatedCollection of `b` produces `a`.
+        // composed RotatedCollection of `b` produces `a`.
         XCTAssertEqual(a, b)
-        XCTAssertEqualSequences(a, bRotated)
+        XCTAssertEqualSequences(a, bRotatedI)
       }
     }
   }


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This is an implementation of non-mutating variant for `rotate(toStartAt:)` and `rotate(subrange:toStartAt:)` 
that are `rotated(toStartAt:)` and `rotated(subrange:toStartAt:)` respectively that results in a `RotatedCollection` view.
The useful aspects of such API is that when preserving the original collection, the mutating version requires a copy. Also, when base conforms to `RandomAccessCollection` calling `rotated` is O(1) time and elements at each position are also computed in constant time. 

Couple of other points to note:
* `Rotate.md` documentation was updated with new variants. Not sure if was worth a new file both for implementation or docs. So opted to keep everything together. 
* Tests to ensure that both mutating and non-mutating variants produce the same result.
* There is also a point worth discussing together with this, that is #165, if that is a useful API modification and if both PRs are useful additions we can land together. 

Let me know what you think @natecook1000 @timvermeulen @lorentey  

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
