### PR TITLE
`XCTAssertUnorderedEqualSequences`: Improve algorithmic complexity when elements are `Hashable` (Resolves #176)

### DIFF
--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -86,6 +86,8 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
 
 /// Asserts two sequences contain exactly the same elements but not necessarily
 /// in the same order.
+/// - Complexity: O(*n* * *m*) where *n* is the number of elements in the first
+/// sequence and *m* is the number of elements in the second sequence
 func XCTAssertUnorderedEqualSequences<S1: Sequence, S2: Sequence>(
   _ expression1: @autoclosure () throws -> S1,
   _ expression2: @autoclosure () throws -> S2,

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -89,8 +89,15 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
 func XCTAssertUnorderedEqualSequences<S1: Sequence, S2: Sequence>(
   _ expression1: @autoclosure () throws -> S1,
   _ expression2: @autoclosure () throws -> S2,
+  _ message: @autoclosure () -> String = "",
   file: StaticString = #file, line: UInt = #line
 ) rethrows where S1.Element: Equatable, S1.Element == S2.Element {
+  func fail(_ reason: String) {
+    let message = message()
+    XCTFail(message.isEmpty ? reason : "\(message) - \(reason)",
+            file: file, line: line)
+  }
+  
   var s1 = Array(try expression1())
   var missing: [S1.Element] = []
   for elt in try expression2() {
@@ -101,15 +108,14 @@ func XCTAssertUnorderedEqualSequences<S1: Sequence, S2: Sequence>(
     s1.remove(at: idx)
   }
   
-  XCTAssertTrue(
-    missing.isEmpty, "first sequence missing '\(missing)' elements from second sequence",
-    file: file, line: line
-  )
+  if !missing.isEmpty {
+    fail("first sequence missing '\(missing)' elements from second sequence")
+  }
+  
+  if !s1.isEmpty {
+    fail("first sequence contains \(s1) missing from second sequence")
+  }
 
-  XCTAssertTrue(
-    s1.isEmpty, "first sequence contains \(s1) missing from second sequence",
-    file: file, line: line
-  )
 }
 
 func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(

--- a/Tests/SwiftAlgorithmsTests/TestUtilities.swift
+++ b/Tests/SwiftAlgorithmsTests/TestUtilities.swift
@@ -84,7 +84,8 @@ func XCTAssertEqualSequences<S1: Sequence, S2: Sequence>(
     message(), file: file, line: line)
 }
 
-// Two sequences contains exactly the same element but not necessarily in the same order.
+/// Asserts two sequences contain exactly the same elements but not necessarily
+/// in the same order.
 func XCTAssertUnorderedEqualSequences<S1: Sequence, S2: Sequence>(
   _ expression1: @autoclosure () throws -> S1,
   _ expression2: @autoclosure () throws -> S2,


### PR DESCRIPTION
Resolves https://github.com/apple/swift-algorithms/issues/176

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
