### PR TITLE
Update Suffix.swift

### DIFF
--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -46,7 +46,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  internal func endOfPrefix(
+  public func endOfPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Index {
     var index = startIndex
@@ -72,7 +72,7 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  internal func startOfSuffix(
+  public func startOfSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Index {
     var index = endIndex


### PR DESCRIPTION
Change `endOfPrefix(while:)` and `startOfSuffix(while:)` from internal to public

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

These two functions are generally useful so they should be public instead of internal
See https://forums.swift.org/t/should-there-be-bidirectionalcollection-droplast-while/48059/14
and https://forums.swift.org/t/endofprefix-while-and-startofsuffix-while-should-be-public-instead-of-internal/56855

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
