### PR TITLE
Corrects variable name in max functions to better reflect usage

### DIFF
--- a/Sources/Algorithms/MinMax.swift
+++ b/Sources/Algorithms/MinMax.swift
@@ -125,7 +125,7 @@ extension Sequence {
   /// largest values:
   ///
   ///     let numbers = [7, 1, 6, 2, 8, 3, 9]
-  ///     let smallestThree = numbers.max(count: 3, sortedBy: <)
+  ///     let largestThree = numbers.max(count: 3, sortedBy: <)
   ///     // [7, 8, 9]
   ///
   /// If you need to sort a sequence but only need to access its largest
@@ -197,7 +197,7 @@ extension Sequence where Element: Comparable {
   /// largest values:
   ///
   ///     let numbers = [7, 1, 6, 2, 8, 3, 9]
-  ///     let smallestThree = numbers.max(count: 3)
+  ///     let largestThree = numbers.max(count: 3)
   ///     // [7, 8, 9]
   ///
   /// If you need to sort a sequence but only need to access its largest
@@ -280,7 +280,7 @@ extension Collection {
   /// largest values:
   ///
   ///     let numbers = [7, 1, 6, 2, 8, 3, 9]
-  ///     let smallestThree = numbers.max(count: 3, sortedBy: <)
+  ///     let largestThree = numbers.max(count: 3, sortedBy: <)
   ///     // [7, 8, 9]
   ///
   /// If you need to sort a collection but only need to access its largest


### PR DESCRIPTION
The variable smallestThree should really be named largestThree. Looks like this was originally a copy paste error from the min documentation.

I noticed this error in the code section of the docs for max. This change only affects documentation and does not affect any actual code.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
