### PR TITLE
Specify dependency URL in consistent fashion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             targets: ["Algorithms"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
All this does is add the `.git` suffix to the package URL for `swift-numerics`. Why do this?

- Consistency. A majority of the other Apple-published Swift ecosystem packages (`swift-logging`, `swift-crypto`, `swift-certificates`, `swift-asn1`, `swift-collections`, `swift-docc`, `swift-nio`, `swift-argument-parser`, `swift-atomics`, and so on) use the `.git`-suffixed form, if not exclusively, then more often than not.
- It makes a difference. If, for example, the same dependency is specified more than once in a given dependency graph and the use of the suffix is inconsistent, SwiftPM does take notice (although the message is only shown when `-v` is in use):
  ```
  info: 'swift-algorithms': dependency on 'swift-numerics' is represented by similar locations
  ('https://github.com/apple/swift-numerics.git' and 'https://github.com/apple/swift-numerics')
  which are treated as the same canonical location 'github.com/apple/swift-numerics'.
  ```
- It makes a _noticeable_ difference; which form ends up in `Package.resolved` tends to change between SwiftPM versions, as well as when the file is updated by Xcode versus the commandline tooling. For projects which commit `Package.resolved` to their Git repos, this results in annoyances like "unclean Git status with no changes made" or "why does Package.resolved change back and forth in every single commit on this branch?"
- Doing this has no meaningful impact in any functional sense; there's no need to tag a release for this change, it'll just get picked up next time something happens that _does_ warrant a release.