### PR TITLE
Chunked type / documentation cleanup

### DIFF
--- a/Guides/Chunked.md
+++ b/Guides/Chunked.md
@@ -63,7 +63,8 @@ let nearlyEvenChunks = (0..<15).evenlyChunked(in: 4)
 
 When "chunking" a collection, the entire collection is included in the result,
 unlike the `split` family of methods, where separators are dropped.
-Joining the result of a chunking method call recreates the original collection.
+Joining the result of a chunking method call results in a collection equivalent
+to the original.
 
 ```swift
 c.elementsEqual(c.chunked(...).joined())
@@ -90,7 +91,7 @@ extension Collection {
       
     public func chunks(ofCount count: Int) -> ChunkedByCount<Self>
       
-    public func evenlyChunked(in count: Int) -> EvenChunks<Self>
+    public func evenlyChunked(in count: Int) -> EvenlyChunkedCollection<Self>
 }
 
 extension LazyCollectionProtocol {
@@ -106,7 +107,7 @@ extension LazyCollectionProtocol {
 
 Each of the "chunked" collection types are bidirectional when the wrapped
 collection is bidirectional. `ChunksOfCountCollection` and 
-`EvenChunksCollection` also conform to `RandomAccessCollection` and 
+`EvenlyChunkedCollection` also conform to `RandomAccessCollection` and 
 `LazySequenceProtocol` when their base collections conform.
 
 ### Complexity

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -190,7 +190,7 @@ final class ChunkedTests: XCTestCase {
   }
   
   func testEvenChunksIndexTraversals() {
-    let validator = IndexValidator<EvenChunksCollection<Range<Int>>>()
+    let validator = IndexValidator<EvenlyChunkedCollection<Range<Int>>>()
 
     [
       (0..<10).evenlyChunked(in: 1),


### PR DESCRIPTION
This change improves the documentation for `evenlyChunked(in:)` and `chunks(ofCount:)` and renames `EvenChunksCollection` to `EvenlyChunkedCollection` to follow the pattern of wrapper type names matching their producing functions.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
