### PR TITLE
Make trimming helper methods public

### DIFF
--- a/Sources/Algorithms/Documentation.docc/Trimming.md
+++ b/Sources/Algorithms/Documentation.docc/Trimming.md
@@ -25,3 +25,8 @@ Remove unwanted elements from the start, the end, or both ends of a collection.
 ### Finding the Suffix of a Collection
 
 - ``Swift/BidirectionalCollection/suffix(while:)``
+
+### Finding Boundaries within a Collection
+
+- ``Swift/Collection/endOfPrefix(while:)``
+- ``Swift/BidirectionalCollection/startOfSuffix(while:)``

--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -46,7 +46,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  internal func endOfPrefix(
+  public func endOfPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Index {
     var index = startIndex
@@ -72,7 +72,7 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  internal func startOfSuffix(
+  public func startOfSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Index {
     var index = endIndex

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -32,7 +32,7 @@ extension Collection {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     let start = try endOfPrefix(while: predicate)
-    return self[start...]
+    return self[start..<endIndex]
   }
 }
 
@@ -61,8 +61,8 @@ extension Collection where Self: RangeReplaceableCollection {
   public mutating func trimPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    let end = try endOfPrefix(while: predicate)
-    removeSubrange(startIndex..<end)
+    let startOfResult = try endOfPrefix(while: predicate)
+    removeSubrange(startIndex..<startOfResult)
   }
 }
 
@@ -135,7 +135,7 @@ extension BidirectionalCollection {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     let end = try startOfSuffix(while: predicate)
-    return self[..<end]
+    return self[startIndex..<end]
   }
 }
 
@@ -188,8 +188,8 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   public mutating func trimSuffix(
     while predicate: (Element) throws -> Bool
   ) rethrows {
-    let start = try startOfSuffix(while: predicate)
-    removeSubrange(start..<endIndex)
+    let endOfResult = try startOfSuffix(while: predicate)
+    removeSubrange(endOfResult..<endIndex)
   }
 }
 

--- a/Tests/SwiftAlgorithmsTests/SuffixTests.swift
+++ b/Tests/SwiftAlgorithmsTests/SuffixTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import Algorithms
+import Algorithms
 
 final class SuffixTests: XCTestCase {
   func testSuffix() {


### PR DESCRIPTION
This supplants #186, making the `endOfPrefix(while:)` and `startOfSuffix(while:)` methods public.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
