### PR TITLE
Add missing backtick to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read more about the package, and the intent behind it, in the [announcement on s
 - [`adjacentPairs()`](https://github.com/apple/swift-algorithms/blob/main/Guides/AdjacentPairs.md): Lazily iterates over tuples of adjacent elements.
 - [`chunked(by:)`, `chunked(on:)`, `chunks(ofCount:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Chunked.md): Eager and lazy operations that break a collection into chunks based on either a binary predicate or when the result of a projection changes or chunks of a given count.
 - [`firstNonNil(_:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/FirstNonNil.md): Returns the first non-`nil` result from transforming a sequence's elements.
-- [`grouped(by:)](https://github.com/apple/swift-algorithms/blob/main/Guides/Grouped.md): Group up elements using the given closure, returning a Dictionary of those groups, keyed by the results of the closure.
+- [`grouped(by:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Grouped.md): Group up elements using the given closure, returning a Dictionary of those groups, keyed by the results of the closure.
 - [`indexed()`](https://github.com/apple/swift-algorithms/blob/main/Guides/Indexed.md): Iterate over tuples of a collection's indices and elements. 
 - [`interspersed(with:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Intersperse.md): Place a value between every two elements of a sequence.
 - [`keyed(by:)`, `keyed(by:resolvingConflictsBy:)`](https://github.com/apple/swift-algorithms/blob/main/Guides/Keyed.md): Returns a Dictionary that associates elements of a sequence with the keys returned by the given closure.


### PR DESCRIPTION
Follow up to #197

Just realized theres a missing <code>`</code> in the README:

<img width="144" alt="image" src="https://github.com/apple/swift-algorithms/assets/5703449/5e70d7d2-024d-459d-9874-38f955450cd0">

### Checklist
- [ ] ~I've added at least one test that validates that my change is working, if appropriate~
- [ ] ~I've followed the code style of the rest of the project~
- [ ] ~I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)~
- [ ] ~I've updated the documentation if necessary~
