### PR TITLE
Remove `@_implementationOnly` annotations

### DIFF
--- a/Sources/Algorithms/RandomSample.swift
+++ b/Sources/Algorithms/RandomSample.swift
@@ -10,8 +10,14 @@
 //===----------------------------------------------------------------------===//
 
 // For log(_:) and root(_:_:)
+#if swift(>=5.11)
+internal import RealModule
+#elseif swift(>=5.10)
+import RealModule
+#else
 @_implementationOnly
 import RealModule
+#endif
 
 //===----------------------------------------------------------------------===//
 // randomStableSample(count:)


### PR DESCRIPTION
These annotations produce warnings when compiling without library evolution using Swift ≥5.10.

Replace them by private import when compiling using Swift ≥5.11.

Mirrors apple/swift-syntax#2429

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
