### PR TITLE
Clarify the docs for `partitioned(by:)`

### DIFF
--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -256,7 +256,7 @@ extension Sequence {
 extension Collection {
   /// Returns two arrays containing the elements of the sequence that
   /// don’t and do satisfy the given predicate, respectively. The order of the
-  /// arrays matches the order of the elements in the original sequence.
+  /// arrays matches the order of the elements in the original collection.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters.

--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -210,8 +210,9 @@ extension Collection {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
-  /// Returns two arrays containing, in order, the elements of the sequence that
-  /// do and don’t satisfy the given predicate.
+  /// Returns two arrays containing the elements of the sequence that
+  /// don’t and do satisfy the given predicate, respectively. The order of the
+  /// arrays matches the order of the elements in the original sequence.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters:
@@ -253,8 +254,9 @@ extension Sequence {
 }
 
 extension Collection {
-  /// Returns two arrays containing, in order, the elements of the collection
-  /// that do and don’t satisfy the given predicate.
+  /// Returns two arrays containing the elements of the sequence that
+  /// don’t and do satisfy the given predicate, respectively. The order of the
+  /// arrays matches the order of the elements in the original sequence.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters.

--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -212,7 +212,8 @@ extension Collection {
 extension Sequence {
   /// Returns two arrays containing the elements of the sequence that
   /// don’t and do satisfy the given predicate, respectively. The order of the
-  /// arrays matches the order of the elements in the original sequence.
+  /// elements in the arrays matches the order of the elements in the original
+  /// sequence.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters:
@@ -254,9 +255,10 @@ extension Sequence {
 }
 
 extension Collection {
-  /// Returns two arrays containing the elements of the sequence that
+  /// Returns two arrays containing the elements of the collection that
   /// don’t and do satisfy the given predicate, respectively. The order of the
-  /// arrays matches the order of the elements in the original collection.
+  /// elements in the arrays matches the order of the elements in the original
+  /// collection.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters.

--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -211,9 +211,7 @@ extension Collection {
 
 extension Sequence {
   /// Returns two arrays containing the elements of the sequence that
-  /// don’t and do satisfy the given predicate, respectively. The order of the
-  /// elements in the arrays matches the order of the elements in the original
-  /// sequence.
+  /// don’t and do satisfy the given predicate, respectively.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters:
@@ -232,7 +230,9 @@ extension Sequence {
   ///
   /// - Returns: Two arrays with all of the elements of the receiver. The
   /// first array contains all the elements that `predicate` didn’t allow, and
-  /// the second array contains all the elements that `predicate` allowed.
+  /// the second array contains all the elements that `predicate` allowed. The
+  /// order of the elements in the arrays matches the order of the elements in
+  /// the original sequence.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
@@ -256,9 +256,7 @@ extension Sequence {
 
 extension Collection {
   /// Returns two arrays containing the elements of the collection that
-  /// don’t and do satisfy the given predicate, respectively. The order of the
-  /// elements in the arrays matches the order of the elements in the original
-  /// collection.
+  /// don’t and do satisfy the given predicate, respectively.
   ///
   /// In this example, `partitioned(by:)` is used to separate the input based on
   /// whether a name is shorter than five characters.
@@ -277,7 +275,9 @@ extension Collection {
   ///
   /// - Returns: Two arrays with all of the elements of the receiver. The
   /// first array contains all the elements that `predicate` didn’t allow, and
-  /// the second array contains all the elements that `predicate` allowed.
+  /// the second array contains all the elements that `predicate` allowed. The
+  /// order of the elements in the arrays matches the order of the elements in
+  /// the original collection.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable


### PR DESCRIPTION
<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

As currently written, the summary for `partitioned(by:)` heavily implies the return value is `(trueValues, falseValues)`. In fact, it’s the opposite. I rephrased this summary to clarify that (1) the order is `(falseValues, trueValues)` and (2) the elements of the two returned arrays are in the order they were in the original sequence/collection.

### Checklist
- (N/A) I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
