### PR TITLE
remove the build warning descripted in #232 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,18 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "Algorithms",
             dependencies: [
               .product(name: "RealModule", package: "swift-numerics"),
-            ]),
+            ],
+            resources: [
+                .process("Documentation.docc")
+            ]
+        ),
         .testTarget(
             name: "SwiftAlgorithmsTests",
             dependencies: ["Algorithms"]),


### PR DESCRIPTION
#232 remove this build warning display as follow:

![image](https://github.com/apple/swift-algorithms/assets/8174538/d35c0a79-9d06-4805-a487-67a2fd24a928)

