### PR TITLE
Detection of One Sorted Sequence Being a Subset of Another

### DIFF
--- a/Guides/Inclusion.md
+++ b/Guides/Inclusion.md
@@ -1,0 +1,74 @@
+#  Inclusion
+
+[[Source](https://github.com/apple/swift-algorithms/blob/main/Sources/Algorithms/Includes.swift) | 
+ [Tests](https://github.com/apple/swift-algorithms/blob/main/Tests/SwiftAlgorithmsTests/IncludesTests.swift)]
+
+Check if one sequence includes another.
+Both sequences must be sorted along the same criteria,
+which must provide a strict weak ordering.
+
+```swift
+let first = [4, 3, 2, 1], second = [3, 2, 1, 0], third = [3, 2]
+let firstIncludesSecond = first.includes(sorted: second, sortedBy: >)  // false
+let secondIncludesThird = second.includes(sorted: third, sortedBy: >)  // true
+let thirdIncludesFirst  = third.includes(sorted: first, sortedBy: >)   // false
+let firstIncludesThird  = first.includes(sorted: third, sortedBy: >)   // true
+let thirdIncludesSecond = third.includes(sorted: second, sortedBy: >)  // false
+let secondIncludesFirst = second.includes(sorted: first, sortedBy: >)  // false
+```
+
+If a predicate is not supplied,
+then the less-than operator is used,
+but only if the `Element` type conforms to `Comparable`.
+
+```swift
+(1...3).includes(sorted: 1..<3)  // true
+```
+
+## Detailed Design
+
+Two new methods are added to `Sequence`:
+
+```swift
+extension Sequence {
+    public func
+    includes<T>(
+                       sorted other: T,
+      sortedBy areInIncreasingOrder: (Element, Element) throws -> Bool
+    ) rethrows -> Bool
+    where T : Sequence, Self.Element == T.Element
+}
+
+extension Sequence where Self.Element : Comparable {
+    @inlinable public func
+    includes<T>(
+      sorted other: T
+    ) -> Bool
+    where T : Sequence, Self.Element == T.Element
+}
+```
+
+The `Sequence.includes(sorted:)` method calls the
+`Sequence.includes(sorted:sortedBy:)` method with the less-than operator for
+the latter's second argument.
+
+### Complexity
+
+Calling either method is O(_n_),
+where *n* is the length of the shorter sequence.
+
+### Naming
+
+These methods' base name is inspired by the C++ function `std::includes`.
+
+### Comparison with Other Languages
+
+**[C++][C++]:** Has an `includes` function family.
+
+**[Haskell][Haskell]:** Has the `isInfixOf` function, plus the `isPrefixOf`,
+`isSuffixOf`, and `isSubsequenceOf` functions.
+
+<!-- Link references for other languages -->
+
+[C++]: https://en.cppreference.com/w/cpp/algorithm/includes
+[Haskell]: https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-List.html#v:isInfixOf

--- a/Sources/Algorithms/Documentation.docc/Algorithms.md
+++ b/Sources/Algorithms/Documentation.docc/Algorithms.md
@@ -40,3 +40,4 @@ Explore more chunking methods and the remainder of the Algorithms package, group
 - <doc:Filtering>
 - <doc:Reductions>
 - <doc:Partitioning>
+- <doc:Inclusion>

--- a/Sources/Algorithms/Documentation.docc/Inclusion.md
+++ b/Sources/Algorithms/Documentation.docc/Inclusion.md
@@ -1,0 +1,12 @@
+#  Inclusion
+
+Check if one sorted sequence is completely contained in another.
+The sort criteria is a user-supplied predicate.
+The predicate can be omitted to default to the less-than operator.
+
+## Topics
+
+### Inclusion
+
+- ``Swift/Sequence/includes(sorted:sortedBy:)``
+- ``Swift/Sequence/includes(sorted:)``

--- a/Sources/Algorithms/Includes.swift
+++ b/Sources/Algorithms/Includes.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// MARK: Sequence.includes(sorted:sortedBy:)
+//-------------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Assuming that this sequence and the given sequence are sorted according
+  /// to the given predicate, determine whether the given sequence is contained
+  /// within this one.
+  ///
+  /// - Precondition: Both the receiver and `other` must be sorted according to
+  ///   `areInIncreasingOrder`, which must be a strict weak ordering over
+  ///   its arguments. Either the receiver, `other`, or both must be finite.
+  ///
+  /// - Parameters:
+  ///   - other: The sequence that is compared against the receiver.
+  ///   - areInIncreasingOrder: The sorting criteria.
+  /// - Returns: Whether the entirety of `other` is contained within this
+  ///   sequence.
+  ///
+  /// - Complexity: O(*n*), where `n` is the length of the shorter sequence.
+  public func includes<T: Sequence>(
+    sorted other: T,
+    sortedBy areInIncreasingOrder: (Element, Element) throws -> Bool
+  ) rethrows -> Bool
+  where T.Element == Element {
+    // Originally, there was a function that evaluated the two sequences'
+    // elements with respect to having elements exclusive to the receiver,
+    // elements exclusive to `other`, and shared elements. But this function
+    // only needs to know when an element that is exclusive to the `other` is
+    // found. So, that function's guts were ripped out and repurposed.
+    var firstElement, secondElement: Element?
+    var iterator = makeIterator(), otherIterator = other.makeIterator()
+    while true {
+      firstElement = firstElement ?? iterator.next()
+      secondElement = secondElement ?? otherIterator.next()
+      switch (firstElement, secondElement) {
+      case let (first?, second?) where try areInIncreasingOrder(first, second):
+        // Found an element exclusive to `self`, move on.
+        firstElement = nil
+      case let (first?, second?) where try areInIncreasingOrder(second, first):
+        // Found an element exclusive to `other`.
+        return false
+      case (_?, _?):
+        // Found a shared element, move on.
+        firstElement = nil
+        secondElement = nil
+      case (nil, _?):
+        // Found an element exclusive to `other`, and any remaining elements
+        // will be exclusive to `other`.
+        return false
+      default:
+        // The elements from `other` (and possibly `self` too) have been
+        // exhausted without disproving inclusion.
+        return true
+      }
+    }
+  }
+}
+
+extension Sequence where Element: Comparable {
+  /// Assuming that this sequence and the given sequence are sorted,
+  /// determine whether the given sequence is contained within this one.
+  ///
+  /// - Precondition: Either the receiver, `other`, or both must be finite.
+  ///
+  /// - Parameter other: The sequence that is compared against the receiver.
+  /// - Returns: Whether the entirety of `other` is contained within this
+  ///   sequence.
+  ///
+  /// - Complexity: O(*n*), where `n` is the length of the shorter sequence.
+  @inlinable
+  public func includes<T: Sequence>(sorted other: T) -> Bool
+  where T.Element == Element {
+    return includes(sorted: other, sortedBy: <)
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/IncludesTests.swift
+++ b/Tests/SwiftAlgorithmsTests/IncludesTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class IncludesTests: XCTestCase {
+  /// Check if one empty set includes another.
+  func testBothSetsEmpty() {
+    XCTAssertTrue(EmptyCollection<Int>().includes(sorted: EmptyCollection()))
+  }
+
+  /// Check if a non-empty set contains an empty one.
+  func testNonemptyIncludesEmpty() {
+    XCTAssertTrue(CollectionOfOne(2).includes(sorted: EmptyCollection()))
+  }
+
+  /// Check if an empty set contains a non-empty one.
+  func testEmptyIncludesNonempty() {
+    XCTAssertFalse(EmptyCollection().includes(sorted: CollectionOfOne(2)))
+  }
+
+  /// Check for inclusion between disjoint (non-empty) sets.
+  func testDisjointSets() {
+    XCTAssertFalse("abc".includes(sorted: "DEF"))
+  }
+
+  /// Check if a non-empty set includes an identical one.
+  func testIdenticalSets() {
+    XCTAssertTrue([0, 1, 2, 3].includes(sorted: 0..<4))
+  }
+
+  /// Check if a set includes a strict non-empty subset.
+  func testStrictSubset() {
+    XCTAssertTrue([0, 1, 2, 3].includes(sorted: 1..<3))
+    XCTAssertTrue([0, 1, 2, 3].includes(sorted: 0..<2))
+    XCTAssertTrue([0, 1, 2, 3].includes(sorted: 2..<4))
+  }
+
+  /// Check if a non-empty set incudes a strict superset.
+  func testStrictSuperset() {
+    XCTAssertFalse([0, 1, 2, 3].includes(sorted: -1..<5))
+    XCTAssertFalse([0, 1, 2, 3].includes(sorted: -1..<4))
+    XCTAssertFalse([0, 1, 2, 3].includes(sorted:  0..<5))
+  }
+
+  /// Check if a non-empty set includes another that shares just some elements.
+  func testOverlap() {
+    XCTAssertFalse([0, 1, 2, 3].includes(sorted:  2..<5))
+    XCTAssertFalse([0, 1, 2, 3].includes(sorted: -1..<2))
+  }
+}


### PR DESCRIPTION
### Description

This function is an adaptation of the [`includes`](https://en.cppreference.com/w/cpp/algorithm/includes) function from C++. This pull request is a sequel to ["Detection of How One Sorted Sequence Includes Another"](https://github.com/apple/swift-algorithms/pull/38) (#38).

I started with a new version of the `Inclusion` type and the `sortedOverlap` function from Pull #38. I added another function, `includes`, that calls the overlap detector then translates the exact overlap degree to a simple `Bool` result.

Then I figured that no one actually cares about the precise overlapping factor. So the precise-overlap function and support type were removed, and its code was moved into `includes` directly. Since a general answer wasn't required, I could add short-circuit logic.

### Detailed Design

One primary function extends `Sequence` to test if a given sequence is a subset of the receiver, assuming both are sorted according to the given predicate. (The given sequence's elements need not be contiguous in the receiver.) The variant function removes the predicate parameter for a default of the less-than operator (`<`), at the cost of requiring `Comparable` conformance.

```swift
extension Sequence {
    public func
    includes<T: Sequence>(sorted other: T, sortedBy areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows -> Bool
    where T.Element == Element
}

extension Sequence where Element: Comparable {
    @inlinable public func
    includes<T: Sequence>(sorted other: T) -> Bool
    where T.Element == Element
}
```

### Documentation Plan

Both introductory documentation and a guide were added.

### Test Plan

A test file was added.

### Source Impact

The functions are an additive change, not otherwise affecting the API.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
