### PR TITLE
Exclude `docc` files from sources to avoid build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
             name: "Algorithms",
             dependencies: [
               .product(name: "RealModule", package: "swift-numerics"),
-            ]),
+            ],
+            exclude: ["Documentation.docc"]),
         .testTarget(
             name: "SwiftAlgorithmsTests",
             dependencies: ["Algorithms"]),


### PR DESCRIPTION
When using this package as a dependency, the following warning appears during the build process:

```
warning: 'swift-algorithms': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/omochi/<myproject>/.build/checkouts/swift-algorithms/Sources/Algorithms/Documentation.docc
```

This happens because `docc` files are treated as undefined source files.
This patch explicitly excludes them using the `exclude` directive, clarifying that they are not source files and preventing the warning from being displayed.

**Relations**
- #245