### PR TITLE
Implement underestimatedCount for Product2Sequence

### DIFF
--- a/Sources/Algorithms/Product.swift
+++ b/Sources/Algorithms/Product.swift
@@ -29,6 +29,15 @@ public struct Product2Sequence<Base1: Sequence, Base2: Collection> {
 extension Product2Sequence: Sequence {
   public typealias Element = (Base1.Element, Base2.Element)
 
+  public var underestimatedCount: Int {
+    // Watch out if at least one source doesn't actually implement their
+    // `underestimatedCount` in constant time
+    // (which `Collection` can permit, unlike `Sequence`).
+    let (product, overflow) = base1.underestimatedCount
+      .multipliedReportingOverflow(by: base2.underestimatedCount)
+    return overflow ? .max : product
+  }
+
   /// The iterator for a `Product2Sequence` sequence.
   public struct Iterator: IteratorProtocol {
     @usableFromInline

--- a/Tests/SwiftAlgorithmsTests/ProductTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ProductTests.swift
@@ -37,6 +37,13 @@ final class ProductTests: XCTestCase {
   func testProductDistanceFromTo() {
     let p = product([1, 2], "abc")
     XCTAssertEqual(p.distance(from: p.startIndex, to: p.endIndex), 6)
+    XCTAssertLessThanOrEqual(p.underestimatedCount, 6)
+  }
+
+  func testOverflowingUnderestimatedCount() {
+    let p = product(repeatElement(true, count: .max / 2),
+                    repeatElement(false, count: .max / 2))
+    XCTAssertLessThanOrEqual(p.underestimatedCount, .max)
   }
 
   func testProductIndexTraversals() {


### PR DESCRIPTION
Add corresponding tests, one for an overflowed count, and one producing a proper count.

Saw this low-hanging fruit while planning other changes. No need for incomplete implementations if they can be realized within reasonable computational time.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
