### PR TITLE
Add labels to the tuples produced by `chunked(on:)`

### DIFF
--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -162,6 +162,7 @@ public struct ChunkedOnCollection<Base: Collection, Subject: Equatable> {
 
 extension ChunkedOnCollection: Collection {
   public typealias Index = ChunkedByCollection<Base, Subject>.Index
+  public typealias Element = (subject: Subject, chunk: Base.SubSequence)
 
   @inlinable
   public var startIndex: Index {
@@ -174,7 +175,7 @@ extension ChunkedOnCollection: Collection {
   }
 
   @inlinable
-  public subscript(position: Index) -> (Subject, Base.SubSequence) {
+  public subscript(position: Index) -> Element {
     let subsequence = chunked[position]
     // swift-format-ignore: NeverForceUnwrap
     // Chunks are never empty, so `.first!` is safe.
@@ -509,7 +510,7 @@ extension Collection {
   @inlinable
   public func chunked<Subject: Equatable>(
     on projection: (Element) throws -> Subject
-  ) rethrows -> [(Subject, SubSequence)] {
+  ) rethrows -> [ChunkedOnCollection<Self, Subject>.Element] {
     guard !isEmpty else { return [] }
     var result: [(Subject, SubSequence)] = []
 

--- a/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ChunkedTests.swift
@@ -71,6 +71,16 @@ final class ChunkedTests: XCTestCase {
     IndexValidator().validate(lazyChunks)
   }
 
+  func testChunkedOnLabels() {
+    let arrayChunks: Array = fruits.chunked(on: { $0.first })
+    XCTAssert(arrayChunks.first!.0 == arrayChunks.first!.subject)
+    XCTAssert(arrayChunks.first!.1 == arrayChunks.first!.chunk)
+
+    let lazyChunks = fruits.lazy.chunked(on: { $0.first })
+    XCTAssert(lazyChunks.first!.0 == lazyChunks.first!.subject)
+    XCTAssert(lazyChunks.first!.1 == lazyChunks.first!.chunk)
+  }
+
   func testChunkedBy() {
     validateFruitChunks(fruits.chunked(by: { $0.first == $1.first }))
 


### PR DESCRIPTION
Label the tuple produced by `chunked(on:)` with `subject` and `chunk`. This will improve the legibility of code downstream of the said function. For example, when providing an identifier for SwiftUI's `ForEach`:

```
-ForEach(chunkedByDate, id: \.0) { date, items in
+ForEach(chunkedByDate, id: \.subject) { date, items in
```

This aligns `ChunkedOnCollection` with the `IndexedCollection`, which specifies `index` and `element` as well as the built-in `EnumeratedSequence` (specifying `offset` and `element`).

The introduction of the label will have no effect on existing code, because the index-based address of the tuple component will remain unchanged and absent labels will be inferred. This said, the label choice should be considered carefully since subsequent relabelings will disrupt established code.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
