### PR TITLE
Add `enable_wasm_sdk_build: true` to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,8 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
 
   soundness:
     name: Soundness


### PR DESCRIPTION
`swift-algorithms` should be built for Wasm as one of the officially supported platforms on CI to prevent possible future regressions.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary
