### PR TITLE
Add `enable_android_sdk_build: true` to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_wasm_sdk_build: true
+      enable_android_sdk_build: true
 
   soundness:
     name: Soundness

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,10 +23,11 @@ jobs:
 
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    #uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swift-android-sdk/github-workflows/.github/workflows/swift_package_test.yml@android-testing
     with:
       enable_wasm_sdk_build: true
-      enable_android_sdk_build: true
+      enable_android_sdk_checks: true
 
   soundness:
     name: Soundness

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,11 +23,10 @@ jobs:
 
   tests:
     name: Test
-    #uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    uses: swift-android-sdk/github-workflows/.github/workflows/swift_package_test.yml@android-testing
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_wasm_sdk_build: true
-      enable_android_sdk_checks: true
+      enable_android_sdk_build: true
 
   soundness:
     name: Soundness


### PR DESCRIPTION
Following the precedent of https://github.com/apple/swift-algorithms/pull/261, `swift-algorithms` should be built for Android as one of the officially supported platforms on CI (added in https://github.com/swiftlang/github-workflows/pull/172) to prevent possible future regressions.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary
