### PR TITLE
solve for accidental quadratic performance from min max methods

### DIFF
--- a/Guides/MinMax.md
+++ b/Guides/MinMax.md
@@ -79,7 +79,7 @@ extension Sequence where Element: Comparable {
 The algorithm used for minimal- or maximal-ordered subsets is based on 
 [Soroush Khanlou's research on this matter](https://khanlou.com/2018/12/analyzing-complexity/). 
 The total complexity is `O(k log k + nk)`, which will result in a runtime close 
-to `O(n)` if *k* is a small amount. If *k* is a large amount (more than 10% of 
+to `O(n)` if *k* is a small amount. If *k* is a large amount (more than log n of 
 the collection), we fall back to sorting the entire array. Realistically, this 
 means the worst case is actually `O(n log n)`.
 

--- a/Sources/Algorithms/MinMax.swift
+++ b/Sources/Algorithms/MinMax.swift
@@ -270,9 +270,9 @@ extension Collection {
       return []
     }
 
-    // If we're attempting to prefix more than 10% of the collection, it's
+    // If we're attempting to prefix more than log n of the collection, it's
     // faster to sort everything.
-    guard prefixCount < (self.count / 10) else {
+    guard prefixCount <= self.count._binaryLogarithm() else {
       return Array(try sorted(by: areInIncreasingOrder).prefix(prefixCount))
     }
 
@@ -326,9 +326,9 @@ extension Collection {
       return []
     }
 
-    // If we're attempting to prefix more than 10% of the collection, it's
+    // If we're attempting to suffix more than log n of the collection, it's
     // faster to sort everything.
-    guard suffixCount < (self.count / 10) else {
+    guard suffixCount <= self.count._binaryLogarithm() else {
       return Array(try sorted(by: areInIncreasingOrder).suffix(suffixCount))
     }
 


### PR DESCRIPTION
There seems to be an accidental quadratic happening in the [MixMax](https://github.com/apple/swift-algorithms/blob/main/Guides/MinMax.md) methods.[^1]

We document our worst case performance to be `O(n log n)`. That is our runtime performance if we sort our entire collection of values. Our threshold to sort everything is ten percent of the total count.

If we do *not* sort the entire collection our runtime is `O(k log k + nk)`. The problem is that `nk` component. If `k` is ten percent of `n` this will still grow quadratically with large `n` and we will not be meeting our promise of `O(n log n)` worst case.

One option is to change the logic that computes our threshold. Instead of computing a threshold that scales linearly with `n` we can compute a threshold that scales logarithmically with `n`. This will then help us meet our promise of `O(n log n)` worst case.

The current implementation presented in this diff uses the underscored [`_binaryLogarithm`](https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/Integers.swift#L1290-L1311) method from Standard Library. If we wanted to avoid the underscored API we could also try something similar to what happens in `RandomSample` to switch over methods from `Darwin` and `Numerics`.[^2] Or we could just write our own here in this file.

Here are some benchmarks sampled locally on this new threshold:

```swift
import Algorithms
import Foundation

func Measure<T>(
  _ label: String,
  _ cycles: Int,
  setUp: () -> () = { },
  body: () -> (T),
  condition: (T) -> Bool = { _ in true },
  tearDown: () -> () = { },
) {
  var duration = Duration.nanoseconds(0)
  
  for _ in (1 ... cycles) {
    setUp()
    let clock = ContinuousClock()
    let instant = clock.now
    let result = body()
    duration += instant.duration(to: clock.now)
    precondition(condition(result))
    tearDown()
  }
  
  duration /= cycles
  
  let microseconds = duration.formatted(
    .units(
      allowed: [.microseconds],
      fractionalPart: .show(length: 3)
    )
  )
  print("\(label): \(microseconds)")
}

func Benchmark(
  n: Int,
  cycles: Int
) {
  let a = Array(1 ... n)
  let k = a.count._binaryLogarithm() - 1
  do {
    var temp = a
    Measure("Sort", cycles) {
      temp.shuffle()
    } body: {
      temp.sort()
      return temp[k]
    } condition: { result in
      result == a[k]
    }
  }
  do {
    var temp = a
    Measure("Min", cycles) {
      temp.shuffle()
    } body: {
      return temp.min(count: k + 1)[k]
    } condition: { result in
      result == a[k]
    }
  }
}

func main() {
  let sizes = [100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000]
  for size in sizes {
    print("--- Size: \(size) ---")
    Benchmark(
      n: size,
      cycles: 100
    )
    print()
  }
}

main()

//
//  swift run -c release
//
//  --- Size: 100 ---
//  Sort: 1.907 μs
//  Min: 0.594 μs
//
//  --- Size: 1000 ---
//  Sort: 26.847 μs
//  Min: 2.236 μs
//
//  --- Size: 10000 ---
//  Sort: 375.711 μs
//  Min: 12.840 μs
//
//  --- Size: 100000 ---
//  Sort: 4,738.126 μs
//  Min: 109.005 μs
//
//  --- Size: 1000000 ---
//  Sort: 56,317.570 μs
//  Min: 1,045.142 μs
//
//  --- Size: 10000000 ---
//  Sort: 682,109.937 μs
//  Min: 10,462.117 μs
//
```

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

[^1]: <https://forums.swift.org/t/benchmarks-selection-linear-time-order-statistics/83852>
[^2]: <https://github.com/apple/swift-algorithms/blob/1.2.1/Sources/Algorithms/RandomSample.swift#L12-L41>