### PR TITLE
Add @discardableResult to mutating partition methods

### DIFF
--- a/Sources/Algorithms/Partition.swift
+++ b/Sources/Algorithms/Partition.swift
@@ -63,6 +63,7 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n* log *n*), where *n* is the length of this collection.
   @inlinable
+  @discardableResult
   public mutating func stablePartition(
     subrange: Range<Index>,
     by belongsInSecondPartition: (Element) throws -> Bool
@@ -87,6 +88,7 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n* log *n*), where *n* is the length of this collection.
   @inlinable
+  @discardableResult
   public mutating func stablePartition(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {
@@ -122,6 +124,7 @@ extension MutableCollection {
   ///
   /// - Complexity: O(*n*) where n is the length of the collection.
   @inlinable
+  @discardableResult
   public mutating func partition(
     subrange: Range<Index>,
     by belongsInSecondPartition: (Element) throws -> Bool
@@ -166,6 +169,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///
   /// - Complexity: O(*n*) where n is the length of the collection.
   @inlinable
+  @discardableResult
   public mutating func partition(
     subrange: Range<Index>,
     by belongsInSecondPartition: (Element) throws -> Bool


### PR DESCRIPTION
## Problem

The mutating `partition(by:)` / `stablePartition(by:)` family returns the index of the first element in the second partition, but the methods are not marked `@discardableResult`. Callers who only want the in-place partitioning side effect and don't need the pivot index get an unavoidable "result of call is unused" warning, as requested in #67.

## Change

Add `@discardableResult` to the four mutating partition methods on `MutableCollection` (and the `BidirectionalCollection` overload). `@discardableResult` is purely additive and source-compatible: it only suppresses the unused-result warning for callers that ignore the return value, and changes no runtime behavior. Callers who use the returned index are unaffected.

## Verification

`swift build` and `swift test` pass. No behavioral change; the attribute only affects unused-result diagnostics.

Fixes #67.
