### PR TITLE
Fix broken cross-reference in Keyed guide

### DIFF
--- a/Guides/Keyed.md
+++ b/Guides/Keyed.md
@@ -67,7 +67,7 @@ Calling `keyed(by:)` is an O(_n_) operation.
 
 1. Java's `toMap` is referring to `Map`/`HashMap`, their naming for Dictionaries and other associative collections. It's easy to confuse with the transformation function, `Sequence.map(_:)`.
 2. C#'s `toXXX()` naming doesn't suite Swift well, which tends to prefer `Foo.init` over `toFoo()` methods.
-3. Ruby's `index_by` naming doesn't fit Swift well, where "index" is a specific term (e.g. the `associatedtype Index` on `Collection`). There is also a [`index(by:)`](Index.md) method in swift-algorithms, is specifically to do with matching elements up with their indices, and not any arbitrary derived value.
+3. Ruby's `index_by` naming doesn't fit Swift well, where "index" is a specific term (e.g. the `associatedtype Index` on `Collection`). There is also a [`indexed()`](Indexed.md) method in swift-algorithms, is specifically to do with matching elements up with their indices, and not any arbitrary derived value.
 
 #### Alternative names
 


### PR DESCRIPTION
`Guides/Keyed.md` links `[\`index(by:)\`](Index.md)` — but `Guides/Index.md` doesn't exist, and the package has no `index(by:)` method. The guide it means to reference is `Indexed.md`, which documents `indexed()` (the method the surrounding sentence describes: matching elements up with their indices). Updated both the target and the label.

Also spotted but **not** fixed (couldn't determine the intended target with confidence): `Guides/Chunked.md` line 48 links `[proposed](proposal)` — a literal placeholder left in the text. If someone knows which proposal document this meant (a swift-evolution proposal?), that's a one-word fix.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)