### PR TITLE
Add Sequence.reduce(_:) to complete the reductions family

### DIFF
--- a/Sources/Algorithms/Documentation.docc/Reductions.md
+++ b/Sources/Algorithms/Documentation.docc/Reductions.md
@@ -16,8 +16,21 @@ print(inclusiveRunningTotal)
 // prints [1, 3, 6, 10, 15]
 ```
 
+If you only need the final value, but the combining operation has no natural
+initial result, use the `reduce(_:)` method, which seeds the operation with the
+first element and returns `nil` for an empty sequence:
+
+```swift
+let total = (1...5).reduce(+)
+// total == 15
+
+let none = EmptyCollection<Int>().reduce(+)
+// none == nil
+```
+
 ## Topics
 
+- ``Swift/Sequence/reduce(_:)``
 - ``Swift/Sequence/reductions(_:)``
 - ``Swift/Sequence/reductions(_:_:)``
 - ``Swift/Sequence/reductions(into:_:)``

--- a/Sources/Algorithms/Reduce.swift
+++ b/Sources/Algorithms/Reduce.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Returns the result of combining the elements of the sequence using the
+  /// given closure, or `nil` if the sequence has no elements.
+  ///
+  /// Use this method when the elements themselves are the values being
+  /// combined and there is no natural initial result. The first element of
+  /// the sequence is used as the initial result, and the closure combines
+  /// the running result with each subsequent element:
+  ///
+  /// ```swift
+  /// let numbers = [1, 2, 3, 4]
+  /// let sum = numbers.reduce(+)
+  /// // sum == 10
+  ///
+  /// let none = EmptyCollection<Int>().reduce(+)
+  /// // none == nil
+  /// ```
+  ///
+  /// This method is the single-value counterpart of `reductions(_:)`, which
+  /// additionally returns all of the intermediate results.
+  ///
+  /// - Parameter nextPartialResult: A closure that combines an accumulating
+  ///   result and an element of the sequence into a new accumulating result.
+  /// - Returns: The final accumulated result, or `nil` if the sequence is
+  ///   empty.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  @inlinable
+  public func reduce(
+    _ nextPartialResult: (Element, Element) throws -> Element
+  ) rethrows -> Element? {
+    var iterator = makeIterator()
+    guard var result = iterator.next() else { return nil }
+    while let element = iterator.next() {
+      result = try nextPartialResult(result, element)
+    }
+    return result
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/ReduceTests.swift
+++ b/Tests/SwiftAlgorithmsTests/ReduceTests.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Algorithms
+import XCTest
+
+final class ReduceTests: XCTestCase {
+  struct TestError: Error {}
+
+  func testReduce() {
+    XCTAssertEqual([1, 2, 3, 4].reduce(+), 10)
+    XCTAssertEqual([4].reduce(+), 4)
+    XCTAssertNil(EmptyCollection<Int>().reduce(+))
+
+    // matches the final element of the corresponding reductions
+    let sequence = [3, 1, 4, 1, 5]
+    XCTAssertEqual(sequence.reduce(+), sequence.reductions(+).last)
+  }
+
+  func testReduceNonCommutative() {
+    // combines left-to-right, seeded with the first element
+    XCTAssertEqual([100, 10, 5].reduce(-), 85)
+    XCTAssertEqual(["a", "b", "c"].reduce(+), "abc")
+  }
+
+  func testReduceSinglePassSequence() {
+    // consumes a single-pass sequence exactly once
+    XCTAssertEqual((1...).prefix(4).reduce(+), 10)
+  }
+
+  func testReduceThrows() {
+    XCTAssertThrowsError(
+      try [1, 2].reduce { _, _ in throw TestError() }
+    )
+
+    // the closure is never called for empty or single-element sequences
+    XCTAssertNil(try EmptyCollection<Int>().reduce { _, _ in throw TestError() })
+    XCTAssertEqual(try [7].reduce { _, _ in throw TestError() }, 7)
+  }
+}


### PR DESCRIPTION
### Description

Fixes #241. Of the three `reductions` overloads on `Sequence`, two mirror a standard-library `reduce` overload (`reduce(_:_:)` ↔ `reductions(_:_:)`, `reduce(into:_:)` ↔ `reductions(into:_:)`), but `reductions(_:)` — which seeds the operation with the first element — had no single-value counterpart. This adds it:

```swift
let total = (1...5).reduce(+)
// total == 15

let none = EmptyCollection<Int>().reduce(+)
// none == nil
```

The overload returns `nil` for an empty sequence, per the issue. It is implemented with `rethrows` for consistency with the rest of the package (the typed-throws variant sketched in #241 requires a Swift 6 minimum and an untyped→typed error cast; happy to switch if that's preferred).

### Detailed Design

```swift
extension Sequence {
  @inlinable
  public func reduce(
    _ nextPartialResult: (Element, Element) throws -> Element
  ) rethrows -> Element?
}
```

No lazy variant is needed — the result is a single value, not a sequence.

### Testing

`ReduceTests` covers: multi-element/single-element/empty sequences, agreement with `reductions(_:).last`, left-to-right association for non-commutative operations, single-pass sequence consumption, and error propagation (including that the closure is never invoked for 0- or 1-element sequences). Full suite: 228 tests pass.

### Documentation

Added `reduce(_:)` to the Reductions documentation page with an overview example.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-algorithms/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)